### PR TITLE
Business Link and Directgov logos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'lograge', '0.0.6'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '1.2.4'
+  gem 'slimmer', '2.0.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,8 +139,7 @@ GEM
     simplecov-html (0.4.5)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (1.2.4)
-      gds-api-adapters (>= 0.0.33, < 0.3.0)
+    slimmer (2.0.0)
       json
       nokogiri (~> 1.5.0)
       null_logger
@@ -195,7 +194,7 @@ DEPENDENCIES
   shoulda (= 2.11.3)
   simplecov (= 0.4.2)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 1.2.4)
+  slimmer (= 2.0.0)
   test-unit (= 2.4.2)
   therubyracer (= 0.10.2)
   timecop (= 0.4.5)

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -1,4 +1,8 @@
+require 'gds_api/helpers'
+
 class CalendarController < ApplicationController
+  include GdsApi::Helpers
+
   before_filter :find_scope
   before_filter :find_calendar, :only => :show
 
@@ -14,7 +18,11 @@ class CalendarController < ApplicationController
           format.ics  { render :text => @repository.combined_calendar_for_division(params[:division]).to_ics }
           format.html { simple_404 }
         else
-          format.html { render "show_#{@scope_view_name}" }
+          format.html do
+            @artefact = fetch_artefact(:slug => @scope)
+            set_slimmer_artefact(@artefact)
+            render "show_#{@scope_view_name}"
+          end
           format.json { @divisions.each {|key, i| @divisions[key].delete(:whole_calendar) }
             render :json => @divisions.to_json }
         end

--- a/test/functional/calendar_controller_test.rb
+++ b/test/functional/calendar_controller_test.rb
@@ -1,5 +1,30 @@
 require 'test_helper'
+require 'gds_api/test_helpers/panopticon'
 
 class CalendarControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::Panopticon
 
+  context "GET 'index'" do
+    setup do
+      stub_panopticon_default_artefact
+    end
+
+    should "send analytics headers" do
+      get :index, :scope => "bank-holidays"
+
+      assert_equal "Life in the UK".downcase,  @response.headers["X-Slimmer-Section"].downcase
+      assert_equal "121",             @response.headers["X-Slimmer-Need-ID"].to_s
+      assert @response.headers["X-Slimmer-Format"].present?
+      assert_equal "citizen",         @response.headers["X-Slimmer-Proposition"]
+    end
+
+    should "send artefact from panopticon to slimmer" do
+      mock_artefact = {'slug' => 'bank-holidays', "name" => "UK bank holidays"}
+      GdsApi::Panopticon.any_instance.expects(:artefact_for_slug).with('bank-holidays').returns(mock_artefact)
+
+      @controller.expects(:set_slimmer_artefact).with(mock_artefact)
+
+      get :index, :scope => "bank-holidays"
+    end
+  end
 end

--- a/test/integration/calendars_test.rb
+++ b/test/integration/calendars_test.rb
@@ -59,15 +59,6 @@ class CalendarsTest < ActionDispatch::IntegrationTest
         end
       end
     end
-
-    should "send analytics headers" do
-      get "/bank-holidays"
-
-      assert_equal "Life in the UK".downcase,  @response.headers["X-Slimmer-Section"].downcase
-      assert_equal "121",             @response.headers["X-Slimmer-Need-ID"].to_s
-      assert @response.headers["X-Slimmer-Format"].present?
-      assert_equal "citizen",         @response.headers["X-Slimmer-Proposition"]
-    end
   end
 
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,6 +1,12 @@
 require 'test_helper'
 require 'capybara/rails'
+require 'gds_api/test_helpers/panopticon'
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
+  include GdsApi::TestHelpers::Panopticon
+
+  setup do
+    stub_panopticon_default_artefact
+  end
 end


### PR DESCRIPTION
Update to slimmer 2.0 to set classes for businesslink and directgov logos.  alphagov/static#20 should be merged first.
