### PR TITLE
Remove deprecated citizen class

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,9 +5,7 @@
     <%= stylesheet_link_tag 'calendar' %>
     <%= yield :head %>
   </head>
-  <%# The citizen class is going to be deprecated, to be replaced with mainstream. %>
-  <%# Added the mainstream class in preparation for the change. %>
-  <body class="citizen mainstream">
+  <body class="mainstream">
     <div id="wrapper" class="answer">
       <%= yield %>
 


### PR DESCRIPTION
Everything that was using it has now been switched to reference
mainstream.
