### PR TITLE
preparing for new Plek

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '2.1.0'
+  gem 'gds-api-adapters', '4.1.3'
 end
 
 group :test do
@@ -30,7 +30,7 @@ group :test do
   gem 'shoulda', '2.11.3'
   gem 'simplecov', '0.4.2'
   gem 'simplecov-rcov', '0.2.3'
-  gem 'webmock', '1.7.8', require: false
+  gem 'webmock', '1.8.0', require: false
   gem 'ci_reporter', '1.6.5'
   gem 'test-unit', '2.5.2'
   gem 'capybara', '1.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.1.5)
-    gds-api-adapters (2.1.0)
+    gds-api-adapters (4.1.3)
       lrucache (~> 0.1.1)
       null_logger
       plek
@@ -161,8 +161,8 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    webmock (1.7.8)
-      addressable (~> 2.2, > 2.2.5)
+    webmock (1.8.0)
+      addressable (>= 2.2.7)
       crack (>= 0.1.7)
     xml-simple (1.1.1)
     xpath (0.1.4)
@@ -176,7 +176,7 @@ DEPENDENCIES
   capybara (= 1.1.2)
   ci_reporter (= 1.6.5)
   exception_notification (= 2.5.2)
-  gds-api-adapters (= 2.1.0)
+  gds-api-adapters (= 4.1.3)
   govuk_frontend_toolkit (= 0.3.3)
   json (= 1.7.4)
   lograge (= 0.0.6)
@@ -193,4 +193,4 @@ DEPENDENCIES
   timecop (= 0.4.5)
   uglifier
   unicorn (= 4.3.1)
-  webmock (= 1.7.8)
+  webmock (= 1.8.0)


### PR DESCRIPTION
bumping gds-api-adapters to 4.1.3 (which required webmock update) to ensure we're stable before rolling out new Plek (with reduced reliance) across all apps. (new Plek required updates to gds-api-adapters)
