### PR TITLE
Remove exception notifier initializer

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,6 +1,0 @@
-unless Rails.env.development? or Rails.env.test?
-  Rails.application.config.middleware.use ExceptionNotifier,
-    :email_prefix => "[#{Rails.application.class.name.split('::').first} (#{Plek.current.environment})] ",
-    :sender_address => %{"Winston Smith-Churchill" <winston@alphagov.co.uk>},
-    :exception_recipients => %w{govuk-exceptions@digital.cabinet-office.gov.uk}
-end


### PR DESCRIPTION
once alphagov/alphagov-deployment#62 goes through, we don't need this anymore.
