### PR TITLE
Quick accessibility fixes - BLOCKED UNTIL SLIMMER UPDATES

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -9,9 +9,7 @@
     <hgroup>
       <h1><span>Quick answer</span> <%= @calendar.title %></h1>
     </hgroup>
-    <nav class="skip-to-related">
-      <a href="#related">Not what you're looking for? ↓</a>
-    </nav>
+    <a class="skip-to-related" href="#related">Not what you're looking for? ↓</a>
   </header>
 
   <div class="article-container group">
@@ -19,13 +17,13 @@
     <article role="article" class="group">
       <div class="inner">
 
-        <nav class="js-tabs nav-tabs" role="navigation">
+        <div class="js-tabs nav-tabs">
           <ul>
             <% @calendar.divisions.each do |division| %>
               <li><%= link_to division.title, "##{division.slug}", :class => division.slug %></li>
             <% end %>
           </ul>
-        </nav>
+        </div>
 
         <div class="js-tab-content tab-content">
           <% @calendar.divisions.each do |division| %>

--- a/app/views/calendar/gwyliau_banc.html.erb
+++ b/app/views/calendar/gwyliau_banc.html.erb
@@ -9,9 +9,7 @@
     <hgroup>
     <h1><span>Ateb cyflym</span> Gwyliau banc y DU</h1>
     </hgroup>
-    <nav class="skip-to-related">
-      <a href="#related">Ddim beth rydych chi'n chwilio amdano? ↓</a>
-    </nav>
+    <a class="skip-to-related" href="#related">Ddim beth rydych chi'n chwilio amdano? ↓</a>
   </header>
 
   <div class="article-container group">
@@ -19,13 +17,13 @@
     <article role="article" class="group">
       <div class="inner">
 
-        <nav class="js-tabs nav-tabs" role="navigation">
+        <div class="js-tabs nav-tabs">
           <ul>
             <% @calendar.divisions.each do |division| %>
               <li><%= link_to division.title, "##{division.slug}", :class => division.slug %></li>
             <% end %>
           </ul>
-        </nav>
+        </div>
 
         <div class="js-tab-content tab-content">
           <% @calendar.divisions.each do |division| %>


### PR DESCRIPTION
Feedback from an accessibility review showed misuse of the `nav` tag was making the document difficult to read:

https://www.pivotaltracker.com/story/show/47377249

Tabs do not need to be wrapped in `nav` tags as they are already identified by their role attribute.
Skiplinks do not need to be wrapped in `nav` tags.

Note: needs to be merged with the following pull requests:

https://github.com/alphagov/static/pull/238
https://github.com/alphagov/frontend/pull/328
https://github.com/alphagov/trade-tariff-frontend/pull/75
