### PR TITLE
Fix ics output to do all-day events correctly.

### DIFF
--- a/lib/ics_renderer.rb
+++ b/lib/ics_renderer.rb
@@ -19,7 +19,8 @@ class ICSRenderer
 
   def render_event(event, sequence)
     output =  "BEGIN:VEVENT\r\n"
-    output << "DTEND;VALUE=DATE:#{ event.date.strftime("%Y%m%d") }\r\n"
+    # The end date is defined as non-inclusive in the RFC (2445 section 4.6.1)
+    output << "DTEND;VALUE=DATE:#{ (event.date + 1.day).strftime("%Y%m%d") }\r\n"
     output << "DTSTART;VALUE=DATE:#{ event.date.strftime("%Y%m%d") }\r\n"
     output << "SUMMARY:#{ event.title }\r\n"
     output << "UID:#{uid(sequence)}\r\n"

--- a/test/integration/icalendar_test.rb
+++ b/test/integration/icalendar_test.rb
@@ -32,7 +32,8 @@ class IcalendarTest < ActionDispatch::IntegrationTest
 
       expected = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:PUBLISH\r\nPRODID:-//uk.gov/GOVUK calendars//EN\r\nCALSCALE:GREGORIAN\r\n"
       expected_events.each_with_index do |event,i|
-        expected << "BEGIN:VEVENT\r\nDTEND;VALUE=DATE:#{event["date"]}\r\nDTSTART;VALUE=DATE:#{event["date"]}\r\nSUMMARY:#{event["title"]}\r\n"
+        end_date = (Date.parse(event["date"]) + 1.day).strftime("%Y%m%d")
+        expected << "BEGIN:VEVENT\r\nDTEND;VALUE=DATE:#{end_date}\r\nDTSTART;VALUE=DATE:#{event["date"]}\r\nSUMMARY:#{event["title"]}\r\n"
         expected << "UID:#{path_hash}-#{i}@gov.uk\r\nSEQUENCE:0\r\nDTSTAMP:20121017T010000Z\r\nEND:VEVENT\r\n"
       end
       expected << "END:VCALENDAR\r\n"

--- a/test/unit/ics_renderer_test.rb
+++ b/test/unit/ics_renderer_test.rb
@@ -48,7 +48,7 @@ class ICSRendererTest < ActiveSupport::TestCase
       @r.expects(:uid).with(2).returns("sdaljksafd-2@gov.uk")
 
       expected =  "BEGIN:VEVENT\r\n"
-      expected << "DTEND;VALUE=DATE:20120414\r\n"
+      expected << "DTEND;VALUE=DATE:20120415\r\n"
       expected << "DTSTART;VALUE=DATE:20120414\r\n"
       expected << "SUMMARY:An Event\r\n"
       expected << "UID:sdaljksafd-2@gov.uk\r\n"


### PR DESCRIPTION
RFC 2445 (section 4.6.1) specifies that a VEVENT end date is
non-inclusive, therefore for all-day events, the end date should be the
following day.
