### PR TITLE
Removing 'not what you're looking for' link

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -9,8 +9,6 @@
     <div>
       <h1><%= @calendar.title %></h1>
     </div>
-    <a class="skip-to-related" href="#related">Not what you're looking for? ↓</a>
-
   </header>
 
   <div class="article-container group">

--- a/app/views/calendar/gwyliau_banc.html.erb
+++ b/app/views/calendar/gwyliau_banc.html.erb
@@ -9,9 +9,6 @@
     <div>
     <h1>Gwyliau banc y DU</h1>
     </div>
-
-    <a class="skip-to-related" href="#related">Ddim beth rydych chi'n chwilio amdano? ↓</a>
-
   </header>
 
   <div class="article-container group">

--- a/app/views/calendar/when_do_the_clocks_change.html.erb
+++ b/app/views/calendar/when_do_the_clocks_change.html.erb
@@ -5,9 +5,6 @@
     <div>
       <h1><%= @calendar.title %></h1>
     </div>
-    <nav class="skip-to-related">
-      <a href="#related">Not what you're looking for? ↓</a>
-    </nav>
   </header>
 
   <div class="article-container group">


### PR DESCRIPTION
Usage is negligible (0.352% of pageviews result in it being clicked) and it's a jarring experience

Related pull requests on other branches — 

alphagov/frontend/pull/512
alphagov/smart-answers/pull/700
alphagov/licence-finder/pull/51
alphagov/calendars/pull/57
alphagov/prototyping-v2/pull/1
alphagov/transaction-wrappers/pull/42
