### PR TITLE
Change format of registerable calendar to register needs with panopticon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '8.2.1'
+  gem 'gds-api-adapters', '10.10.1'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.1.5)
-    gds-api-adapters (8.2.1)
+    gds-api-adapters (10.10.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -189,7 +189,7 @@ DEPENDENCIES
   capybara (= 1.1.2)
   ci_reporter (= 1.6.5)
   exception_notification (= 2.5.2)
-  gds-api-adapters (= 8.2.1)
+  gds-api-adapters (= 10.10.1)
   govuk_frontend_toolkit (= 0.32.2)
   json (= 1.7.4)
   logstasher (= 0.4.8)

--- a/lib/registerable_calendar.rb
+++ b/lib/registerable_calendar.rb
@@ -7,7 +7,7 @@ class RegisterableCalendar
 
   attr_accessor :calendar, :slug, :live
 
-  def_delegators :@calendar, :title, :need_id, :description, :indexable_content
+  def_delegators :@calendar, :title, :description, :indexable_content
 
   def initialize(path)
     details = JSON.parse(File.read(path))
@@ -17,6 +17,10 @@ class RegisterableCalendar
 
   def state
     'live'
+  end
+
+  def need_ids
+    [@calendar.need_id.to_s]
   end
 
   def paths


### PR DESCRIPTION
upgrade api adapters
send need_ids instead of need_id
enforce need_ids to be an array of strings
