### PR TITLE
Adding gem to strip Client-IP headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'govuk_frontend_toolkit', '~> 1.5.0'
 
 gem 'logstasher', '0.4.8'
 gem 'airbrake', '3.1.15'
+gem 'rack_strip_client_ip', '0.0.1'
 gem 'unicorn', '4.3.1'
 
 if ENV['SLIMMER_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
+    rack_strip_client_ip (0.0.1)
     rails (3.2.17)
       actionmailer (= 3.2.17)
       actionpack (= 3.2.17)
@@ -188,6 +189,7 @@ DEPENDENCIES
   logstasher (= 0.4.8)
   mocha (= 0.13.3)
   plek (= 1.3.1)
+  rack_strip_client_ip (= 0.0.1)
   rails (= 3.2.17)
   rails-i18n!
   sass-rails (= 3.2.3)


### PR DESCRIPTION
We've seen a few instances of IpSpoofAttackError in Errbit recently, @alext's rack_strip_client_ip gem will hush these.

Detailed explanation here - https://github.com/alphagov/whitehall/pull/810
