### PR TITLE
Update to work with slimmer wrapper layout

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -8,6 +8,7 @@
 @import "styleguide/_colours";
 @import "styleguide/_conditionals2";
 
+
 .highlighted-event {
 
 	padding: 1.75em 0.75em 1.25em 0.75em;
@@ -73,7 +74,7 @@
 	}
 }
 
-article { 
+article {
 	.subscribe {
 		background: none;
 		padding:0 0 0 1em;
@@ -95,7 +96,7 @@ article {
     			background-size: 29px 24px;
   			}
 			}
-		}	
+		}
 	}
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,9 +8,11 @@
   </head>
   <body class="mainstream">
     <div id="wrapper" class="answer <%= yield :wrapper_class %>">
-      <%= yield %>
+      <div class="grid-row">
+        <%= yield %>
 
-      <div id="related-items"></div>
+        <div id="related-items"></div>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
In updating the wrapper layout in static this needs to be accounted for
in this application. Add a grid-row div so the related and main columns
float.

This is the matching pull request to go with this one on static: alphagov/static#530