### PR TITLE
Adding a (hidden) date allows spreadsheet programs to parse dates when copy/pasting

### DIFF
--- a/app/views/calendar/_calendar_by_year.html.erb
+++ b/app/views/calendar/_calendar_by_year.html.erb
@@ -9,7 +9,9 @@
     <tbody>
       <% events.each do |event| %>
         <tr>
-          <td class="calendar_date"><%= l event.date, :format => '%e %B' %></td>
+          <td class="calendar_date">
+            <%= l event.date, :format => '%e %B' %>&nbsp;<span class="visuallyhidden" aria-hidden="true"><%= l event.date, :format => '%Y' %></span>
+          </td>
           <td class="calendar_day"><%= l event.date, :format => '%A' %></td>
           <td class="calendar_title"><%= event.title %><%= " (#{event.notes.downcase})" unless event.notes.blank? %></td>
         </tr>


### PR DESCRIPTION
For example, copying a table into excel or google drive, if the value of the date cell
is '2 April' then it will be detected as a date, but the year will default to the current.

For past/future years this results in the wrong year. If we provide a visually and AT
hidden year for this case then the date will be parsed entirely correctly.

This is doubly-hidden content, but as it's entirely progrmatic its unlikely to go stale,
as static copy may.

**Note**: I could not get this to work without the `&nbsp;`. With a regular space it would copy as `D M Y`, but be treated by google drive as `D MY`.

Thoughts?