### PR TITLE
Bump slimmer to 8.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'unicorn', '4.3.1'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '3.25.0'
+  gem 'slimmer', '8.1.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,12 +140,12 @@ GEM
     simplecov-html (0.4.5)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (3.25.0)
+    slimmer (8.1.0)
+      activesupport
       json
-      lrucache (~> 0.1.3)
-      nokogiri (~> 1.5.0)
+      nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
-      plek (>= 0.1.8)
+      plek (>= 1.1.0)
       rack (>= 1.3.5)
       rest-client
     sprockets (2.2.3)
@@ -196,7 +196,7 @@ DEPENDENCIES
   shoulda (= 2.11.3)
   simplecov (= 0.4.2)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 3.25.0)
+  slimmer (= 8.1.0)
   test-unit (= 2.5.2)
   therubyracer (= 0.10.2)
   timecop (= 0.4.5)

--- a/app/views/calendar/_calendar_metadata.html.erb
+++ b/app/views/calendar/_calendar_metadata.html.erb
@@ -1,4 +1,3 @@
-<div id="report-a-problem"></div>
 <div class="meta-data group">
   <div class="inner">
     <p class="modified-date"><%= t 'common.last_updated' %>: <%= l last_updated_date, :format => '%e %B %Y' %></p>


### PR DESCRIPTION
This picks up using meta tags for page metadata (instead of setting
GA custom dimensions).
This upgrade requires removing the report-a-problem div, meaning that
the report-a-problem form is automatically appended to the wrapper
by slimmer.

/cc @fofr 