### PR TITLE
Re-hang the bunting so it looks alright

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -128,7 +128,8 @@ table.clocks-calendar .equal-width {
     height: 50px;
     overflow: visible;
     border-top: 1px solid $grey-8;
-    position: static;
+    position: absolute;
+    left: 0;
 
     @include media-down(tablet) {
       display: none;
@@ -146,29 +147,29 @@ table.clocks-calendar .equal-width {
   }
 
   .related {
-    margin-top:6.5em;
+    margin-top: 4.5em;
 
     @include media(mobile) {
-      margin-top:0;
+      margin-top: 0;
     }
 
     @include media(desktop) {
-      margin-top:6.5em;
+      margin-top: 4.5em;
     }
   }
 
-  main#content {
-    margin-top:1em;
+  #content {
+    margin-top: 4em;
 
     @include media(mobile) {
       margin-top:0;
     }
 
     @include media(desktop) {
-      margin-top:1em;
+      margin-top: 4em;
 
       header.page-header div {
-        background-color:transparent;
+        background-color: transparent;
       }
     }
   }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,93 +11,93 @@
 
 .highlighted-event {
 
-	padding: 1.75em 0.75em 1.25em 0.75em;
+  padding: 1.75em 0.75em 1.25em 0.75em;
 
-	@include media(tablet) {
-		padding: 1.75em 0.75em 1.25em 0.75em;
-	}
+  @include media(tablet) {
+    padding: 1.75em 0.75em 1.25em 0.75em;
+  }
 
-	@include media(mobile) {
-		padding: 0.5em 0.75em 0.25em 0.75em;
-	}
+  @include media(mobile) {
+    padding: 0.5em 0.75em 0.25em 0.75em;
+  }
 
-	p {
-		@include heading-24;
-		font-weight:bold;
-		padding:0;
-		margin:0;
+  p {
+    @include heading-24;
+    font-weight:bold;
+    padding:0;
+    margin:0;
 
-		@include media(mobile) {
-			padding: 0;
-			margin-top: 0;
-			margin-bottom: 0;
-			font-weight:bold;
-			padding: 0;
-			margin:0;
+    @include media(mobile) {
+      padding: 0;
+      margin-top: 0;
+      margin-bottom: 0;
+      font-weight:bold;
+      padding: 0;
+      margin:0;
 
-		}
-	
-		@include media(tablet) {
-			padding:0;
-			margin:0;
-			font-weight:bold;
-		}
+    }
 
-		span {
-			display:block;
-			@include heading-24;
-			font-weight:bold;
-		}
+    @include media(tablet) {
+      padding:0;
+      margin:0;
+      font-weight:bold;
+    }
 
-		em {
-			display:block;
-			@include heading-80;
-			font-weight:bold;
-			margin-bottom: 0;
+    span {
+      display:block;
+      @include heading-24;
+      font-weight:bold;
+    }
 
-			padding:0;
-			padding-top:0.2em;
-			padding-bottom:0.1em;
-			
-			@include media(mobile) {
-				padding:0;
-				padding-top:0.2em;
-				padding-bottom:0.1em;
-			}
+    em {
+      display:block;
+      @include heading-80;
+      font-weight:bold;
+      margin-bottom: 0;
 
-			@include media(tablet) {
-				padding:0;
-				padding-top:0.2em;
-				padding-bottom:0.1em;
-			}
-		}
-	}
+      padding:0;
+      padding-top:0.2em;
+      padding-bottom:0.1em;
+
+      @include media(mobile) {
+        padding:0;
+        padding-top:0.2em;
+        padding-bottom:0.1em;
+      }
+
+      @include media(tablet) {
+        padding:0;
+        padding-top:0.2em;
+        padding-bottom:0.1em;
+      }
+    }
+  }
 }
 
 article {
-	.subscribe {
-		background: none;
-		padding:0 0 0 1em;
+  .subscribe {
+    background: none;
+    padding:0 0 0 1em;
 
-		@include media(tablet) {
-			padding:0.25em 0 0.25em 0;
-		}
+    @include media(tablet) {
+      padding:0.25em 0 0.25em 0;
+    }
 
-		p {
-			a {
-				display: block;
-				font-weight: 600;
-				background: image-url("icon-calendar.png") no-repeat scroll 0 0;
-				min-height: 2.5em;
-				padding: 0 0 0 3em;
+    p {
+      a {
+        display: block;
+        font-weight: 600;
+        background: image-url("icon-calendar.png") no-repeat scroll 0 0;
+        min-height: 2.5em;
+        padding: 0 0 0 3em;
 
-				@include device-pixel-ratio() {
-    			background-image: image-url("icon-calendar-2x.png");
-    			background-size: 29px 24px;
-  			}
-			}
-		}
-	}
+        @include device-pixel-ratio() {
+          background-image: image-url("icon-calendar-2x.png");
+          background-size: 29px 24px;
+        }
+      }
+    }
+  }
 }
 
 /* calendar tables */
@@ -123,54 +123,54 @@ table.clocks-calendar .equal-width {
 
 /* bunting lol */
 .bunted {
-	.epic-bunting {
-	  width: 100%;
-	  height: 50px;
-	  overflow: visible;
-	  border-top: 1px solid $grey-8;
-	  position: static;
+  .epic-bunting {
+    width: 100%;
+    height: 50px;
+    overflow: visible;
+    border-top: 1px solid $grey-8;
+    position: static;
 
-	  @include media-down(tablet) {
-	    display: none;
-	  }
+    @include media-down(tablet) {
+      display: none;
+    }
 
-	  span {
-	    background-image: image-url("bunting.png");
-	    background-color: transparent;
-	    background-repeat: repeat-x;
-	    background-position: center top;
-	    width: 99.9%;
-	    height: 70px;
-	    display: block;
-	  }
-	}
+    span {
+      background-image: image-url("bunting.png");
+      background-color: transparent;
+      background-repeat: repeat-x;
+      background-position: center top;
+      width: 99.9%;
+      height: 70px;
+      display: block;
+    }
+  }
 
-	.related {
-		margin-top:6.5em;
+  .related {
+    margin-top:6.5em;
 
-		@include media(mobile) {
-			margin-top:0;
-		}
+    @include media(mobile) {
+      margin-top:0;
+    }
 
-		@include media(desktop) {
-			margin-top:6.5em;
-		}
-	}
+    @include media(desktop) {
+      margin-top:6.5em;
+    }
+  }
 
-	main#content {
-		margin-top:1em;
+  main#content {
+    margin-top:1em;
 
-		@include media(mobile) {
-			margin-top:0;
-		}
+    @include media(mobile) {
+      margin-top:0;
+    }
 
-		@include media(desktop) {
-			margin-top:1em;
+    @include media(desktop) {
+      margin-top:1em;
 
-			header.page-header div {
-				background-color:transparent;
-			}
-		}
-	}
+      header.page-header div {
+        background-color:transparent;
+      }
+    }
+  }
 
 }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -149,25 +149,19 @@ table.clocks-calendar .equal-width {
   .related {
     margin-top: 4.5em;
 
-    @include media(mobile) {
+    @include media-down(tablet) {
       margin-top: 0;
-    }
-
-    @include media(desktop) {
-      margin-top: 4.5em;
     }
   }
 
   #content {
     margin-top: 4em;
 
-    @include media(mobile) {
-      margin-top:0;
+    @include media-down(tablet) {
+      margin-top: 0;
     }
 
     @include media(desktop) {
-      margin-top: 4em;
-
       header.page-header div {
         background-color: transparent;
       }


### PR DESCRIPTION
Bunting was not showing correctly on a bank holiday. It started from the left side of the grid. 

This PR is in combination with changes to static, which remove the bunting styles that were over there.

* Hang bunting across full page width by positioning absolutely
* Tweak the top margins for content and related links
* Use the same media queries for modifying margins as used for hiding the bunting

There's a white space commit, so I suggest reviewing with `?w=1`

https://www.pivotaltracker.com/story/show/93891364

cc @futurefabric @edds @wryobservations 

# Before
![screen shot 2015-05-05 at 16 12 00](https://cloud.githubusercontent.com/assets/319055/7475775/8ed0063e-f341-11e4-9f89-6a45d6d35e95.png)

# After
![screen shot 2015-05-05 at 16 09 53](https://cloud.githubusercontent.com/assets/319055/7475717/35e87e20-f341-11e4-8ef9-bff8f71a0184.png)
