### PR TITLE
Remove link title

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,7 +25,7 @@ en:
     past_bank_holidays:       "Past bank holidays"
     bank_holiday_on_wkend:    "If a bank holiday is on a weekend, a ‘substitute’ weekday becomes a bank holiday, normally the following Monday."
     holiday_entitlement:      "Your employer doesn’t have to give you <a href=\"/holiday-entitlement-rights\" title=\"Holiday entitlement rights\">paid leave on bank or public holidays</a>."
-    bank_holiday_benefits:    "Bank holidays might affect <a href=\"/how-to-have-your-benefits-paid\" title=\"How and when your benefits are paid\">how and when your benefits are paid</a>."
+    bank_holiday_benefits:    "Bank holidays might affect <a href=\"/how-to-have-your-benefits-paid\">how and when your benefits are paid</a>."
   bank_holidays:
     calendar:
       title:        "UK bank holidays"


### PR DESCRIPTION
Having link text the same as the title makes reading the link out really
repetitive for a screen reader user as it will read the same text twice.

Remove the repeated text as you get all the content you need from the
link text.