### PR TITLE
Add `content_id` to calendars and send to panopticon, content-store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '20.1.1'
+  gem 'gds-api-adapters', '~> 24.3.0'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :test do
   gem 'test-unit', '2.5.2'
   gem 'capybara', '1.1.2'
   gem 'timecop', '0.4.5'
+  gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
 end
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.1.5)
-    gds-api-adapters (20.1.1)
+    gds-api-adapters (24.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -100,7 +100,7 @@ GEM
     null_logger (0.0.1)
     plek (1.3.1)
     polyglot (0.3.5)
-    rack (1.4.6)
+    rack (1.4.7)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-ssl (1.3.4)
@@ -196,7 +196,7 @@ DEPENDENCIES
   airbrake (= 3.1.15)
   capybara (= 1.1.2)
   ci_reporter (= 1.6.5)
-  gds-api-adapters (= 20.1.1)
+  gds-api-adapters (~> 24.3.0)
   govuk_frontend_toolkit (~> 1.5.0)
   json (= 1.7.4)
   logstasher (= 0.4.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
     activesupport (3.2.22)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
-    addressable (2.3.2)
+    addressable (2.3.8)
     airbrake (3.1.15)
       builder
       multi_json
@@ -68,6 +68,8 @@ GEM
       plek
       rack-cache
       rest-client (~> 1.8.0)
+    govuk-content-schema-test-helpers (1.3.0)
+      json-schema (~> 2.5.1)
     govuk_frontend_toolkit (1.5.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -77,6 +79,8 @@ GEM
     i18n (0.7.0)
     journey (1.0.4)
     json (1.7.4)
+    json-schema (2.5.1)
+      addressable (~> 2.3.7)
     kgio (2.7.4)
     libv8 (3.16.14.11)
     libwebsocket (0.1.5)
@@ -197,6 +201,7 @@ DEPENDENCIES
   capybara (= 1.1.2)
   ci_reporter (= 1.6.5)
   gds-api-adapters (~> 24.3.0)
+  govuk-content-schema-test-helpers (~> 1.3.0)
   govuk_frontend_toolkit (~> 1.5.0)
   json (= 1.7.4)
   logstasher (= 0.4.8)

--- a/app/models/services.rb
+++ b/app/models/services.rb
@@ -1,0 +1,7 @@
+require 'gds_api/panopticon'
+
+module Services
+  def self.panopticon
+    @panopticon ||= GdsApi::Panopticon::Registerer.new(owning_app: "calendars")
+  end
+end

--- a/app/models/services.rb
+++ b/app/models/services.rb
@@ -1,7 +1,12 @@
 require 'gds_api/panopticon'
+require 'gds_api/publishing_api'
 
 module Services
   def self.panopticon
     @panopticon ||= GdsApi::Panopticon::Registerer.new(owning_app: "calendars")
+  end
+
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApi.new(Plek.new.find('publishing-api'))
   end
 end

--- a/app/presenters/calendar_content_item.rb
+++ b/app/presenters/calendar_content_item.rb
@@ -1,0 +1,24 @@
+# Renders a calendar for the publishing-api.
+class CalendarContentItem
+  attr_reader :calendar
+
+  def initialize(calendar)
+    @calendar = calendar
+  end
+
+  def base_path
+    '/' + calendar.slug
+  end
+
+  def payload
+    {
+      title: calendar.title,
+      format: 'placeholder_calendar',
+      publishing_app: 'calendars',
+      rendering_app: 'calendars',
+      update_type: 'minor',
+      locale: 'en',
+      public_updated_at: Time.now,
+    }
+  end
+end

--- a/app/presenters/calendar_content_item.rb
+++ b/app/presenters/calendar_content_item.rb
@@ -19,6 +19,9 @@ class CalendarContentItem
       update_type: 'minor',
       locale: 'en',
       public_updated_at: Time.now,
+      routes: [
+        { type: 'exact', path: base_path }
+      ]
     }
   end
 end

--- a/app/services/calendar_publisher.rb
+++ b/app/services/calendar_publisher.rb
@@ -1,0 +1,15 @@
+class CalendarPublisher
+  def initialize(calendar)
+    @calendar = calendar
+  end
+
+  def publish
+    Services.publishing_api.put_content_item(rendered.base_path, rendered.payload)
+  end
+
+private
+
+  def rendered
+    @rendered ||= CalendarContentItem.new(@calendar)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ module Calendars
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    # config.autoload_paths += %W(#{config.root}/extras)
+    config.autoload_paths += %W(#{config.root}/app/services)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -1,6 +1,7 @@
 {
     "title": "bank_holidays.calendar.title",
     "need_id": 100128,
+    "content_id": "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
     "description": "bank_holidays.calendar.description",
     "indexable_content": "",
     "divisions": {

--- a/lib/data/when-do-the-clocks-change.json
+++ b/lib/data/when-do-the-clocks-change.json
@@ -1,6 +1,7 @@
 {
   "title": "When do the clocks change?",
   "need_id": 100933,
+  "content_id": "41c78b38-f70e-4729-815b-680f9b90db30",
   "description": "Dates when the clocks go back or forward in 2014, 2015, 2016 - includes British Summer Time, Greenwich Mean Time",
   "indexable_content": "This clock change gives the UK an extra hour of daylight (sometimes called Daylight Saving Time). From March to October (when the clocks are 1 hour ahead) the UK is on British Summer Time (BST). From October to March, the UK is on Greenwich Mean Time (GMT).",
   "divisions": {

--- a/lib/registerable_calendar.rb
+++ b/lib/registerable_calendar.rb
@@ -7,7 +7,7 @@ class RegisterableCalendar
 
   attr_accessor :calendar, :slug, :live
 
-  def_delegators :@calendar, :indexable_content
+  def_delegators :@calendar, :indexable_content, :content_id
 
   def initialize(path)
     details = JSON.parse(File.read(path))

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -3,14 +3,12 @@ require 'registerable_calendar'
 namespace :panopticon do
   desc "Register application metadata with panopticon"
   task :register => :environment do
-    require 'gds_api/panopticon'
     logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
     logger.info "Registering with panopticon..."
 
-    registerer = GdsApi::Panopticon::Registerer.new(owning_app: "calendars")
     Dir.glob(Rails.root.join("lib/data/*.json")).each do |file|
       details = RegisterableCalendar.new(file)
-      registerer.register(details)
+      Services.panopticon.register(details)
     end
   end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,0 +1,9 @@
+namespace :publishing_api do
+  desc "Send pages to the content-api"
+  task :register => :environment do
+    %w[bank-holidays when-do-the-clocks-change].each do |calender_name|
+      calendar = Calendar.find(calender_name)
+      CalendarPublisher.new(calendar).publish
+    end
+  end
+end

--- a/test/support/content_schema_helpers.rb
+++ b/test/support/content_schema_helpers.rb
@@ -1,0 +1,21 @@
+require 'govuk-content-schema-test-helpers/test_unit'
+
+module Mocha
+  module ParameterMatchers
+    def valid_payload_for(format_name)
+      ValidSchemaMatcher.new(format_name)
+    end
+
+    class ValidSchemaMatcher < Base
+      def initialize(format_name)
+        @format_name = format_name
+      end
+
+      def matches?(available_parameters)
+        payload = available_parameters.shift
+        validator = GovukContentSchemaTestHelpers::Validator.new(@format_name, JSON.dump(payload))
+        validator.valid?
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,3 +18,5 @@ GovukContentSchemaTestHelpers.configure do |config|
   config.schema_type = 'publisher'
   config.project_root = Rails.root
 end
+
+Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,3 +13,8 @@ require 'slimmer/test'
 
 require 'webmock/test_unit'
 WebMock.disable_net_connect!(:allow_localhost => true)
+
+GovukContentSchemaTestHelpers.configure do |config|
+  config.schema_type = 'publisher'
+  config.project_root = Rails.root
+end

--- a/test/unit/panopticon_registration_test.rb
+++ b/test/unit/panopticon_registration_test.rb
@@ -12,7 +12,7 @@ class PanopticonRegistrationTest < ActiveSupport::TestCase
       calendar = RegisterableCalendar.new(file_path)
       artefact = registerer.record_to_artefact(calendar)
 
-      [:name, :description, :slug].each do |key|
+      [:name, :description, :slug, :content_id].each do |key|
         assert artefact.has_key?(key), "Missing attribute: #{key}"
         assert ! artefact[key].nil?, "Attribute #{key} is nil"
       end

--- a/test/unit/panopticon_registration_test.rb
+++ b/test/unit/panopticon_registration_test.rb
@@ -1,16 +1,14 @@
 require_relative '../test_helper'
 
-require 'gds_api/panopticon'
 require 'registerable_calendar'
 
 class PanopticonRegistrationTest < ActiveSupport::TestCase
   context "Panopticon registration" do
     should "translate to Panopticon artefacts" do
-      registerer = GdsApi::Panopticon::Registerer.new(owning_app: "calendars")
       file_path = Rails.root.join(*%w(lib data bank-holidays.json))
 
       calendar = RegisterableCalendar.new(file_path)
-      artefact = registerer.record_to_artefact(calendar)
+      artefact = Services.panopticon.record_to_artefact(calendar)
 
       [:name, :description, :slug, :content_id].each do |key|
         assert artefact.has_key?(key), "Missing attribute: #{key}"

--- a/test/unit/presenters/calendar_content_item_test.rb
+++ b/test/unit/presenters/calendar_content_item_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+require 'govuk-content-schema-test-helpers/test_unit'
+
+class CalendarContentItemTest < ActiveSupport::TestCase
+  include GovukContentSchemaTestHelpers::TestUnit
+
+  def test_payload_is_valid_against_schema
+    calendar = Calendar.find('bank-holidays')
+
+    payload = CalendarContentItem.new(calendar).payload
+
+    assert_valid_against_schema payload, 'placeholder'
+  end
+
+  def test_payload_contains_correct_data
+    calendar = Calendar.find('bank-holidays')
+
+    payload = CalendarContentItem.new(calendar).payload
+
+    assert_equal 'UK bank holidays', payload[:title]
+  end
+
+  def test_base_path_is_correct
+    calendar = Calendar.find('bank-holidays')
+
+    base_path = CalendarContentItem.new(calendar).base_path
+
+    assert_equal '/bank-holidays', base_path
+  end
+end

--- a/test/unit/services/calendar_publisher_test.rb
+++ b/test/unit/services/calendar_publisher_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class CalendarPublisherTest < ActiveSupport::TestCase
+  def test_publishing_to_publishing_api
+    Services.publishing_api.expects(:put_content_item).with(
+      "/bank-holidays",
+      valid_payload_for('placeholder')
+    )
+
+    calendar = Calendar.find('bank-holidays')
+
+    CalendarPublisher.new(calendar).publish
+  end
+end


### PR DESCRIPTION
This commit adds a `content_id` (generated in the console with `SecureRandom.uuid`) to the two calendars.

By updating `gds-api-adapters` and exposing a `content_id` method on `RegisterableCalendar`, this attribute is automatically sent to panopticon. Also sends the calendars to the content-store.

https://trello.com/c/A94Y5Ect