### PR TITLE
Send content_id to publishing-api

### DIFF
--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -51,4 +51,8 @@ class Calendar
       hash[I18n.t(division.slug)] = division.as_json
     end
   end
+
+  def content_id
+    @data["content_id"]
+  end
 end

--- a/app/presenters/calendar_content_item.rb
+++ b/app/presenters/calendar_content_item.rb
@@ -13,6 +13,7 @@ class CalendarContentItem
   def payload
     {
       title: calendar.title,
+      content_id: calendar.content_id,
       format: 'placeholder_calendar',
       publishing_app: 'calendars',
       rendering_app: 'calendars',

--- a/test/fixtures/data/bank-holidays.json
+++ b/test/fixtures/data/bank-holidays.json
@@ -1,6 +1,7 @@
 {
     "title": "bank_holidays.calendar.title",
     "need_id": 100128,
+    "content_id": "58f79dbd-e57f-4ab2-ae96-96df5767d1b2",
     "description": "bank_holidays.calendar.description",
     "indexable_content": "",
     "divisions": {

--- a/test/unit/presenters/calendar_content_item_test.rb
+++ b/test/unit/presenters/calendar_content_item_test.rb
@@ -18,6 +18,7 @@ class CalendarContentItemTest < ActiveSupport::TestCase
     payload = CalendarContentItem.new(calendar).payload
 
     assert_equal 'UK bank holidays', payload[:title]
+    assert payload[:content_id].is_a?(String)
   end
 
   def test_base_path_is_correct


### PR DESCRIPTION
PR #93 sets up the infrastructure for sending the `content_id` to the content-store very nicely, but completely forgets to actually _send the the content_id to the content-store_.

:flushed: 

Trello: https://trello.com/c/A94Y5Ect