### PR TITLE
Use key base from env var

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,3 +15,8 @@ development:
 
 test:
   secret_key_base: '97eb5ad29b493ac9f666fba282d75810717dc935783636f833ed7b3a0af09b036beb1855e3320d3cf7177f16124243e272f510eefeb104b634cdec7bb69cb9a3'
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
This commit changes Calendars to use the secret key base env var that is
set in Puppet.