### PR TITLE
Fix asset prefix and image paths

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -87,12 +87,12 @@ article {
       a {
         display: block;
         font-weight: 600;
-        background: image-url("icon-calendar.png") no-repeat scroll 0 0;
+        background: image-path("icon-calendar.png") no-repeat scroll 0 0;
         min-height: 2.5em;
         padding: 0 0 0 3em;
 
         @include device-pixel-ratio() {
-          background-image: image-url("icon-calendar-2x.png");
+          background-image: image-path("icon-calendar-2x.png");
           background-size: 29px 24px;
         }
       }

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,7 @@ module Calendars
     # Enable the asset pipeline
     config.assets.enabled = true
 
+    config.assets.prefix = '/calendars'
     config.assets.precompile += %w(
       application.css
       print.css


### PR DESCRIPTION
The asset prefix was removed by mistake in the upgrade to Rails 4
https://github.com/alphagov/calendars/commit/abc5a1b2c6368c7230c8e4e593c444e7e0231d3f