### PR TITLE
Use V2 of publishing-api to write calendars to the content store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 24.4.0'
+  gem 'gds-api-adapters', '~> 25.1'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.1.5)
-    gds-api-adapters (24.4.0)
+    gds-api-adapters (25.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -122,7 +122,7 @@ GEM
       byebug (~> 5.0)
       pry (~> 0.10)
     rack (1.6.4)
-    rack-cache (1.5.0)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -227,7 +227,7 @@ DEPENDENCIES
   airbrake (= 3.1.15)
   capybara (= 1.1.2)
   ci_reporter_minitest (= 1.0.0)
-  gds-api-adapters (~> 24.4.0)
+  gds-api-adapters (~> 25.1)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk_frontend_toolkit (~> 1.5.0)
   json (~> 1.8.3)

--- a/app/presenters/calendar_content_item.rb
+++ b/app/presenters/calendar_content_item.rb
@@ -10,14 +10,23 @@ class CalendarContentItem
     '/' + calendar.slug
   end
 
+  def update_type
+    'minor'
+  end
+
+  def content_id
+    calendar.content_id
+  end
+
   def payload
     {
       title: calendar.title,
-      content_id: calendar.content_id,
+      base_path: base_path,
+      content_id: content_id,
       format: 'placeholder_calendar',
       publishing_app: 'calendars',
       rendering_app: 'calendars',
-      update_type: 'minor',
+      update_type: update_type,
       locale: 'en',
       public_updated_at: Time.current.to_datetime.rfc3339,
       routes: [

--- a/app/services/calendar_publisher.rb
+++ b/app/services/calendar_publisher.rb
@@ -4,7 +4,8 @@ class CalendarPublisher
   end
 
   def publish
-    Services.publishing_api.put_content_item(rendered.base_path, rendered.payload)
+    Services.publishing_api.put_content(rendered.content_id, rendered.payload)
+    Services.publishing_api.publish(rendered.content_id, rendered.update_type)
   end
 
 private

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,7 +1,7 @@
-require 'gds_api/publishing_api'
+require 'gds_api/publishing_api_v2'
 
 module Services
   def self.publishing_api
-    @publishing_api ||= GdsApi::PublishingApi.new(Plek.new.find('publishing-api'))
+    @publishing_api ||= GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
   end
 end

--- a/test/unit/services/calendar_publisher_test.rb
+++ b/test/unit/services/calendar_publisher_test.rb
@@ -2,10 +2,8 @@ require 'test_helper'
 
 class CalendarPublisherTest < ActiveSupport::TestCase
   def test_publishing_to_publishing_api
-    Services.publishing_api.expects(:put_content_item).with(
-      "/bank-holidays",
-      valid_payload_for('placeholder')
-    )
+    Services.publishing_api.expects(:put_content).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2", valid_payload_for('placeholder'))
+    Services.publishing_api.expects(:publish).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2", 'minor')
 
     calendar = Calendar.find('bank-holidays')
 


### PR DESCRIPTION
All apps should now use v2 of the publishing api to write content to the content-store. This change converts calendars to use v2 of the api. The differences are:

- put content_item is replaced by two methods - put_content, and publish
- the content_id is used as the key, rather than the base path
- the base path is included in the payload