### PR TITLE
Use V2 schema testing

### DIFF
--- a/app/presenters/calendar_content_item.rb
+++ b/app/presenters/calendar_content_item.rb
@@ -22,11 +22,9 @@ class CalendarContentItem
     {
       title: calendar.title,
       base_path: base_path,
-      content_id: content_id,
       format: 'placeholder_calendar',
       publishing_app: 'calendars',
       rendering_app: 'calendars',
-      update_type: update_type,
       locale: 'en',
       public_updated_at: Time.current.to_datetime.rfc3339,
       routes: [

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ require 'webmock/minitest'
 WebMock.disable_net_connect!(:allow_localhost => true)
 
 GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = 'publisher'
+  config.schema_type = 'publisher_v2'
   config.project_root = Rails.root
 end
 

--- a/test/unit/presenters/calendar_content_item_test.rb
+++ b/test/unit/presenters/calendar_content_item_test.rb
@@ -18,7 +18,6 @@ class CalendarContentItemTest < ActiveSupport::TestCase
     payload = CalendarContentItem.new(calendar).payload
 
     assert_equal 'UK bank holidays', payload[:title]
-    assert payload[:content_id].is_a?(String)
   end
 
   def test_base_path_is_correct


### PR DESCRIPTION
We should test against the new v2 schemas. Doing this uncovered that `update_type` and `content_id` were being sent, while they shouldn't.

https://trello.com/c/catWOsWC