### PR TITLE
Add CORS headers for JSON requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,8 @@ class ApplicationController < ActionController::Base
 
   slimmer_template 'wrapper'
 
+  before_action :set_cors_headers, if: :json_request?
+
 protected
 
   def error_503(e); error(503, e); end
@@ -26,5 +28,15 @@ protected
 
   def set_expiry(age = 60.minutes)
     expires_in age, public: true unless Rails.env.development?
+  end
+
+  def set_cors_headers
+    # Calendars only does GET requests, so it's safe to allow CORS for all
+    # requests.
+    headers['Access-Control-Allow-Origin'] = '*'
+  end
+
+  def json_request?
+    request.format.symbol == :json
   end
 end

--- a/test/functional/calendar_controller_test.rb
+++ b/test/functional/calendar_controller_test.rb
@@ -75,6 +75,12 @@ class CalendarControllerTest < ActionController::TestCase
         get :calendar, scope: 'bank-holidays', format: :json
         assert_equal "max-age=3600, public", response.headers["Cache-Control"]
       end
+
+      should "set the CORS headers" do
+        get :calendar, scope: 'bank-holidays', format: :json
+
+        assert_equal "*", response.headers['Access-Control-Allow-Origin']
+      end
     end
 
     should "404 for a non-existent calendar" do


### PR DESCRIPTION
This adds CORS headers for JSON requests so the data can be used directly by javascript applications. This was requested in https://github.com/alphagov/calendars/issues/113.

This pattern was taken from the e-petitions application (https://github.com/alphagov/e-petitions/pull/382).

To be reviewed by @daibach or @alexmuller.