### PR TITLE
Fix schema testing

### DIFF
--- a/app/presenters/calendar_content_item.rb
+++ b/app/presenters/calendar_content_item.rb
@@ -22,10 +22,12 @@ class CalendarContentItem
     {
       title: calendar.title,
       base_path: base_path,
-      format: 'placeholder_calendar',
+      document_type: 'placeholder_calendar',
+      schema_name: 'placeholder_calendar',
       publishing_app: 'calendars',
       rendering_app: 'calendars',
       locale: 'en',
+      details: {},
       public_updated_at: Time.current.to_datetime.rfc3339,
       routes: [
         { type: 'exact', path: base_path }

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export REPO_NAME="alphagov/govuk-content-schemas"
+export CONTEXT_MESSAGE="Verify calendars against content schemas"
+
+exec ./jenkins.sh


### PR DESCRIPTION
This fixes the payload sent to the publishing-api and adds a script that will be used to test this application from PRs against https://github.com/alphagov/govuk-content-schemas.

