### PR TITLE
Rake task to add calendars to the search index

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,19 @@ The division `title` attribute is optional.  If this is not present the slug wil
 
 ### Dependencies
 
-- [panopticon](https://github.com/alphagov/panopticon): this app sends data to panopticon to register URLs and for search indexing.
+- [panopticon](https://github.com/alphagov/panopticon): this app sends data to panopticon to register URLs.
+- [rummager](https://github.com/alphagov/rummager): this app indexes its pages for search via Rummager.
 - [publishing-api](https://github.com/alphagov/publishing-api): this app sends data to the content-store.
 
 ### Additional information
 
 #### Publishing to GOV.UK
 
-- `bundle exec rake panopticon:register` will send the calendars to panopticon. Panopticon will register the URL and send the data to Rummager for indexing in search.
+- `bundle exec rake panopticon:register` will send the calendars to panopticon. Panopticon will register the URL.
+
+#### Search indexing
+
+- `bundle exec rake rummager:index_all` will send the data to Rummager for indexing in search.
 
 #### Generate bank holidays JSON
 

--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -1,0 +1,30 @@
+class SearchPayloadPresenter
+  attr_reader :registerable_calendar
+  delegate :slug,
+           :title,
+           :description,
+           :indexable_content,
+           :content_id,
+           to: :registerable_calendar
+
+  def initialize(registerable_calendar)
+    @registerable_calendar = registerable_calendar
+  end
+
+  def self.call(registerable_calendar)
+    new(registerable_calendar).call
+  end
+
+  def call
+    {
+      content_id: content_id,
+      rendering_app: 'calendars',
+      publishing_app: 'calendars',
+      format: 'custom-application',
+      title: title,
+      description: description,
+      indexable_content: indexable_content,
+      link: "/#{slug}"
+    }
+  end
+end

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -1,0 +1,30 @@
+class SearchIndexer
+  attr_reader :registerable_calendar
+  delegate :slug, to: :registerable_calendar
+
+  def initialize(registerable_calendar)
+    @registerable_calendar = registerable_calendar
+  end
+
+  def self.call(registerable_calendar)
+    new(registerable_calendar).call
+  end
+
+  def call
+    Services.rummager.add_document(document_type, document_id, payload)
+  end
+
+private
+
+  def document_type
+    'edition'
+  end
+
+  def document_id
+    "/#{slug}"
+  end
+
+  def payload
+    SearchPayloadPresenter.call(registerable_calendar)
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,4 +1,5 @@
 require 'gds_api/publishing_api_v2'
+require 'gds_api/rummager'
 
 module Services
   def self.publishing_api
@@ -6,5 +7,9 @@ module Services
       Plek.new.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
     )
+  end
+
+  def self.rummager
+    @rummager ||= GdsApi::Rummager.new(Plek.find("search"))
   end
 end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,0 +1,17 @@
+require 'registerable_calendar'
+
+namespace :rummager do
+  desc "Indexes all calendars in Rummager"
+  task index_all: :environment do
+    require 'gds_api/rummager'
+
+    logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
+
+    Dir.glob(Rails.root.join("lib/data/*.json")).each do |file|
+      details = RegisterableCalendar.new(file)
+      logger.info "Indexing '#{details.title}' in rummager..."
+
+      SearchIndexer.call(details)
+    end
+  end
+end

--- a/test/unit/services/search_indexer_test.rb
+++ b/test/unit/services/search_indexer_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class SearchIndexerTest < ActiveSupport::TestCase
+  def test_indexing_to_rummager
+    registerable_calendar = RegisterableCalendar.new(
+      Rails.root + 'lib/data/bank-holidays.json'
+    )
+    Services.rummager.expects(:add_document).with(
+      'edition',
+      '/bank-holidays',
+      content_id: '58f79dbd-e57f-4ab2-ae96-96df5767d1b2',
+      rendering_app: "calendars",
+      publishing_app: "calendars",
+      format: "custom-application",
+      title: "UK bank holidays",
+      description:  "Find out when bank holidays are in England, Wales, Scotland and Northern Ireland - including past and future bank holidays",
+      indexable_content: "",
+      link: '/bank-holidays',
+    )
+
+    SearchIndexer.call(registerable_calendar)
+  end
+end


### PR DESCRIPTION
Previously, panopticon would send artifacts to Rummager. That flow is now being
deprecated in favour of a simpler approach which is to send documents directly
to rummager.

This commit adds a class that allows us to add calendars to the search index
directly. It also adds a rake task `rummager:index_all` which goes through all
calendars and indexes them in the search index.

Before, the search results in `search-admin` looked like this:

<img width="1182" alt="screen shot 2016-09-19 at 10 31 16" src="https://cloud.githubusercontent.com/assets/416701/18627785/cf97fd58-7e54-11e6-9a46-62a314176f8d.png">

After the change, it looks like this:

<img width="1199" alt="screen shot 2016-09-19 at 11 21 10" src="https://cloud.githubusercontent.com/assets/416701/18629619/a5fd124e-7e5e-11e6-9c16-2dbc3c86596f.png">

The payload now includes the following extra attributes:
- publishing_app
- rendering_app
- content_id

Trello ticket: https://trello.com/c/gsHnT5WF/161-epic-send-things-to-rummager-directly-instead-of-via-panopticon