### PR TITLE
Correct rummager rake task name

### DIFF
--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -2,7 +2,7 @@ require 'registerable_calendar'
 
 namespace :rummager do
   desc "Indexes all calendars in Rummager"
-  task index_all: :environment do
+  task index: :environment do
     require 'gds_api/rummager'
 
     logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }


### PR DESCRIPTION
This ensures the rummager:index task defined in govuk-app-deployment can·
correctly invoke this task.