### PR TITLE
[WIP] markup events as microdata

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,7 +49,7 @@
       font-weight: bold;
     }
 
-    em {
+    time {
       display: block;
       @include heading-80;
       font-weight: bold;

--- a/app/views/calendar/_calendar_by_year.html.erb
+++ b/app/views/calendar/_calendar_by_year.html.erb
@@ -11,10 +11,14 @@
         <tr itemscope itemtype="http://schema.org/Event">
           <meta itemprop="location" content="<%=t("#{location}")%>" />
           <td class="calendar-date">
-            <time itemprop="startDate" datetime="<%= event.date %>"><%= l event.date, :format => '%e %B' %></time>
+            <time itemprop="startDate" datetime="<%= event.date %>">
+              <%= l event.date, :format => '%e %B' %>
+            </time>
           </td>
           <td class="calendar-day"><%= l event.date, :format => '%A' %></td>
-          <td class="calendar-title" itemprop="name"><%= event.title %><%= " (#{event.notes.downcase})" unless event.notes.blank? %></td>
+          <td class="calendar-title" itemprop="name">
+            <%= event.title %><%= " (#{event.notes.downcase})" unless event.notes.blank? %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/calendar/_calendar_by_year.html.erb
+++ b/app/views/calendar/_calendar_by_year.html.erb
@@ -8,10 +8,13 @@
     </thead>
     <tbody>
       <% events.each do |event| %>
-        <tr>
-          <td class="calendar-date"><%= l event.date, :format => '%e %B' %></td>
+        <tr itemscope itemtype="http://schema.org/Event">
+          <meta itemprop="location" content="<%=t("#{location}")%>" />
+          <td class="calendar-date">
+            <time itemprop="startDate" datetime="<%= event.date %>"><%= l event.date, :format => '%e %B' %></time>
+          </td>
           <td class="calendar-day"><%= l event.date, :format => '%A' %></td>
-          <td class="calendar-title"><%= event.title %><%= " (#{event.notes.downcase})" unless event.notes.blank? %></td>
+          <td class="calendar-title" itemprop="name"><%= event.title %><%= " (#{event.notes.downcase})" unless event.notes.blank? %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -28,11 +28,12 @@
           <% @calendar.divisions.each do |division| %>
             <div class="js-tab-pane tab-pane" id="<%=t division.slug %>">
               <% if division.upcoming_event %>
-                <div class="highlighted-event">
+                <div class="highlighted-event" itemscope itemtype="http://schema.org/Event">
+                  <meta itemprop="location" content="<%=t("#{division.title}")%>" />
                   <p><%=t "common.next_holiday_in_is", :in_nation => t("#{division.title}_in") %></p>
                   <p>
-                    <em><%= division.upcoming_event.date == Date.today ? t("common.today") : l(division.upcoming_event.date, format: "%e %B") %></em>
-                    <span><%=division.upcoming_event.title %></span>
+                    <time itemprop="startDate" datetime="<%=division.upcoming_event.date%>"><%= division.upcoming_event.date == Date.today ? t("common.today") : l(division.upcoming_event.date, format: "%e %B") %></time>
+                    <span itemprop="name"><%=division.upcoming_event.title %></span>
                   </p>
                 </div>
               <% end %>
@@ -45,6 +46,7 @@
               </div>
 
               <%= render :partial => 'calendar_by_year', :locals => {
+                  :location => division.title,
                   :events_by_year => division.upcoming_events_by_year,
                   :caption => "#{t "common.upcoming_bank_holidays"} #{t "#{division.title}_in"}"} %>
 
@@ -53,6 +55,7 @@
               <p><%= raw(t("common.bank_holiday_benefits"))%></p>
 
               <%= render :partial => 'calendar_by_year', :locals => {
+                  :location => division.title,
                   :events_by_year => division.past_events_by_year,
                   :caption => "#{t "common.past_bank_holidays"} #{t "#{division.title}_in"}"} %>
             </div>

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -32,7 +32,9 @@
                   <meta itemprop="location" content="<%=t("#{division.title}")%>" />
                   <p><%=t "common.next_holiday_in_is", :in_nation => t("#{division.title}_in") %></p>
                   <p>
-                    <time itemprop="startDate" datetime="<%=division.upcoming_event.date%>"><%= division.upcoming_event.date == Date.today ? t("common.today") : l(division.upcoming_event.date, format: "%e %B") %></time>
+                    <time itemprop="startDate" datetime="<%=division.upcoming_event.date%>">
+                      <%= division.upcoming_event.date == Date.today ? t("common.today") : l(division.upcoming_event.date, format: "%e %B") %>
+                    </time>
                     <span itemprop="name"><%=division.upcoming_event.title %></span>
                   </p>
                 </div>

--- a/app/views/calendar/when_do_the_clocks_change.html.erb
+++ b/app/views/calendar/when_do_the_clocks_change.html.erb
@@ -29,8 +29,18 @@
             <% division.years.each do |year| -%>
               <tr>
                 <th scope="row"><%= year %></th>
-                <td itemscope itemtype="http://schema.org/Event"><meta itemprop="name" content="Clocks go forward"/><time itemprop="startDate" datetime="<%= year.events[0].date %>"><%= year.events[0].date.strftime('%e %B') %></td>
-                <td itemscope itemtype="http://schema.org/Event"><meta itemprop="name" content="Clocks go back"/><time itemprop="startDate" datetime="<%= year.events[1].date %>"><%= year.events[1].date.strftime('%e %B') %></td>
+                <td itemscope itemtype="http://schema.org/Event">
+                  <meta itemprop="name" content="Clocks go forward"/>
+                  <time itemprop="startDate" datetime="<%= year.events[0].date %>">
+                    <%= year.events[0].date.strftime('%e %B') %>
+                  </time>
+                </td>
+                <td itemscope itemtype="http://schema.org/Event">
+                  <meta itemprop="name" content="Clocks go back"/>
+                  <time itemprop="startDate" datetime="<%= year.events[1].date %>">
+                    <%= year.events[1].date.strftime('%e %B') %>
+                  </time>
+                </td>
               </tr>
             <% end -%>
           </tbody>

--- a/app/views/calendar/when_do_the_clocks_change.html.erb
+++ b/app/views/calendar/when_do_the_clocks_change.html.erb
@@ -13,9 +13,9 @@
         <%- division = @calendar.divisions.first -%>
 
         <% if division.upcoming_event %>
-          <div class="highlighted-event">
-            <p>The <%= division.upcoming_event.notes.gsub(' one hour', '').downcase %>
-              <em><%= division.upcoming_event.date.strftime("%e %B") %></em></p>
+          <div class="highlighted-event" itemscope itemtype="http://schema.org/Event">
+            <p itemprop="name">The <%= division.upcoming_event.notes.gsub(' one hour', '').downcase %>
+              <time itemprop="startDate" datetime="<%= division.upcoming_event.date %>"><%= division.upcoming_event.date.strftime("%e %B") %></time></p>
           </div>
         <% end %>
 
@@ -29,8 +29,8 @@
             <% division.years.each do |year| -%>
               <tr>
                 <th scope="row"><%= year %></th>
-                <td><%= year.events[0].date.strftime('%e %B') %></td>
-                <td><%= year.events[1].date.strftime('%e %B') %></td>
+                <td itemscope itemtype="http://schema.org/Event"><meta itemprop="name" content="Clocks go forward"/><time itemprop="startDate" datetime="<%= year.events[0].date %>"><%= year.events[0].date.strftime('%e %B') %></td>
+                <td itemscope itemtype="http://schema.org/Event"><meta itemprop="name" content="Clocks go back"/><time itemprop="startDate" datetime="<%= year.events[1].date %>"><%= year.events[1].date.strftime('%e %B') %></td>
               </tr>
             <% end -%>
           </tbody>


### PR DESCRIPTION
Calendar pages contain very simple information that could be presented to the user without them even visiting the page.

At the moment, it seems like search engines don't always understand how to use our calendars to answer the user's query directly and GOV.UK is not always the top result (at least for me).

Here's some examples of google doing the wrong thing (the next bank holiday for England and Wales is in December):

<img width="659" alt="screen shot 2016-09-29 at 15 44 30" src="https://cloud.githubusercontent.com/assets/87579/18962516/17619b3c-8669-11e6-850a-176a6d75c31a.png">
<img width="779" alt="screen shot 2016-09-29 at 16 30 33" src="https://cloud.githubusercontent.com/assets/87579/18962523/1cf4df6e-8669-11e6-8e6a-5c89dd8f5db2.png">
<img width="817" alt="screen shot 2016-09-29 at 16 31 16" src="https://cloud.githubusercontent.com/assets/87579/18962528/239266b6-8669-11e6-89cf-cf37c105ac40.png">

<img width="855" alt="screen shot 2016-09-29 at 16 31 36" src="https://cloud.githubusercontent.com/assets/87579/18962531/28f5c648-8669-11e6-9f31-6512e94bba2e.png">

This branch is an attempt to implement this schema: http://schema.org/Event

WIP HTML:

``` html
                <div class="highlighted-event" itemscope itemtype="http://schema.org/Event">
                  <meta itemprop="location" content="England and Wales">
                  <p>The next bank holiday in England and Wales is</p>
                  <p>
                    <time itemprop="startDate" datetime="2016-12-26">26 December</time>
                    <span itemprop="name">Boxing Day</span>
                  </p>
                </div>
```

This doesn't validate according to https://search.google.com/structured-data/testing-tool/u/0/, although the w3c parser didn't have a problem with it.

I'm not sure if this is a sensible way to deal with "location". I've used a meta tag because it feels like the location is implicit: we only refer to the division in the "in" text and this can differ from the location name:

```
      england-and-wales:      "Cymru a Lloegr"
      england-and-wales_in:   "yng Nghymru a Lloegr"
```
