### PR TITLE
Update gds-api-adapters to 36.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 29.6'
+  gem 'gds-api-adapters', '~> 36.4.0'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,17 +66,17 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     docile (1.1.5)
-    domain_name (0.5.25)
+    domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
-    gds-api-adapters (29.6.0)
+    gds-api-adapters (36.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     govuk-content-schema-test-helpers (1.4.0)
@@ -107,7 +107,9 @@ GEM
       mime-types (>= 1.16, < 4)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mime-types (2.99.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     mocha (1.1.0)
@@ -166,10 +168,10 @@ GEM
     rainbow (2.1.0)
     raindrops (0.16.0)
     rake (10.5.0)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rubocop (0.35.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.3.0, < 3.0)
@@ -230,7 +232,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     unicorn (5.0.1)
       kgio (~> 2.6)
       rack
@@ -249,7 +251,7 @@ DEPENDENCIES
   airbrake (= 4.3.0)
   capybara (= 2.6.2)
   ci_reporter_minitest (= 1.0.0)
-  gds-api-adapters (~> 29.6)
+  gds-api-adapters (~> 36.4.0)
   govuk-content-schema-test-helpers (~> 1.4.0)
   govuk-lint (= 0.8.1)
   govuk_frontend_toolkit (~> 4.9.0)
@@ -272,4 +274,4 @@ DEPENDENCIES
   webmock (= 1.24.2)
 
 BUNDLED WITH
-   1.11.2
+   1.13.1

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,0 +1,1 @@
+GdsApi.config.always_raise_for_not_found = true


### PR DESCRIPTION
Update to the latest version, particularly as we've updated the Panopticon adapter to stop handling search-related attributes (see https://github.com/alphagov/gds-api-adapters/pull/592).