### PR TITLE
Upgrade Slimmer and related code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'uglifier', '2.7.2'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '9.2.1'
+  gem 'slimmer', '10.0.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,13 +205,13 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (9.2.1)
+    slimmer (10.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
       plek (>= 1.1.0)
-      rack (>= 1.3.5)
+      rack
       rest-client
     slop (3.6.0)
     sprockets (3.7.0)
@@ -269,7 +269,7 @@ DEPENDENCIES
   shoulda (= 3.5.0)
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 9.2.1)
+  slimmer (= 10.0.0)
   timecop (= 0.8.0)
   uglifier (= 2.7.2)
   unicorn (~> 5.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,7 +7,6 @@
 // local styleguide includes
 @import "styleguide/colours";
 @import "styleguide/conditionals2";
-@import "helpers/govuk-component-helpers";
 
 .highlighted-event {
 

--- a/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
+++ b/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
@@ -1,7 +1,0 @@
-// GOV.UK components expect to live in a world with a global reset. This CSS
-// might be pushed up to static at some point.
-.govuk-breadcrumbs ol,
-.govuk-related-items ul {
-  padding: 0;
-  margin: 0;
-}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ require "gds_api/helpers"
 
 class ApplicationController < ActionController::Base
   include Slimmer::Template
-  include Slimmer::SharedTemplates
+  include Slimmer::GovukComponents
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -74,10 +74,16 @@ private
 
   def handle_bank_holiday_ics_calendars
     if scope == "bank-holidays"
-      I18n.backend.send(:init_translations) unless I18n.backend.initialized?
-      translations = I18n.backend.send(:translations)
+      i18n_backend.send(:init_translations) unless i18n_backend.initialized?
+      translations = i18n_backend.send(:translations)
       division_key = translations[I18n.locale][:common][:nations].key(params[:division]).to_s
       params[:division] = "common.nations." + division_key
+    end
+  end
+
+  def i18n_backend
+    I18n.backend.backends.detect do |backend|
+      backend.is_a?(I18n::Backend::Simple)
     end
   end
 end

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -74,16 +74,9 @@ private
 
   def handle_bank_holiday_ics_calendars
     if scope == "bank-holidays"
-      i18n_backend.send(:init_translations) unless i18n_backend.initialized?
-      translations = i18n_backend.send(:translations)
-      division_key = translations[I18n.locale][:common][:nations].key(params[:division]).to_s
-      params[:division] = "common.nations." + division_key
-    end
-  end
+      division_slug = Calendar::Division::SLUGS.fetch(params[:division])
 
-  def i18n_backend
-    I18n.backend.backends.detect do |backend|
-      backend.is_a?(I18n::Backend::Simple)
+      params[:division] = "common.nations.#{division_slug}"
     end
   end
 end

--- a/app/models/calendar/division.rb
+++ b/app/models/calendar/division.rb
@@ -1,5 +1,14 @@
 class Calendar
   class Division
+    SLUGS = {
+      "england-and-wales" => "england-and-wales_slug",
+      "cymru-a-lloegr" => "england-and-wales_slug",
+      "northern-ireland" => "northern-ireland_slug",
+      "gogledd-iwerddon" => "northern-ireland_slug",
+      "scotland" => "scotland_slug",
+      "yr-alban" => "scotland_slug",
+    }.freeze
+
     attr_reader :slug, :title
 
     def initialize(slug, data = {})

--- a/test/integration/icalendar_test.rb
+++ b/test/integration/icalendar_test.rb
@@ -8,34 +8,64 @@ class IcalendarTest < ActionDispatch::IntegrationTest
       File.stubs(:mtime).with(Rails.root.join("REVISION")).returns(Time.parse("2012-10-17 01:00:00"))
     end
 
-    should "contain all events in the given division" do
-      path = "/bank-holidays/england-and-wales.ics"
-      get path
+    calendars = {
+      "welsh" => "/gwyliau-banc/cymru-a-lloegr.ics",
+      "welsh-scotland" => "/gwyliau-banc/yr-alban.ics",
+      "welsh-nothern-ireland" => "/gwyliau-banc/gogledd-iwerddon.ics",
+      "english" => "/bank-holidays/england-and-wales.ics",
+      "english-scotland" => "/bank-holidays/scotland.ics",
+      "english-northern-ireland" => "/bank-holidays/northern-ireland.ics",
+    }
 
-      expected_events = [
-        { "date" => "20120102", "title" => "New Year’s Day" },
-        { "date" => "20120604", "title" => "Spring bank holiday" },
-        { "date" => "20120605", "title" => "Queen’s Diamond Jubilee" },
-        { "date" => "20120827", "title" => "Summer bank holiday" },
-        { "date" => "20121225", "title" => "Christmas Day" },
-        { "date" => "20121226", "title" => "Boxing Day" },
-        { "date" => "20130101", "title" => "New Year’s Day" },
-        { "date" => "20130329", "title" => "Good Friday" },
-        { "date" => "20131225", "title" => "Christmas Day" },
-        { "date" => "20131226", "title" => "Boxing Day" },
-      ]
+    calendars.each do |calendar, calendar_path|
+      should "contain all events in #{calendar}" do
+        get calendar_path
+        assert_equal response.status, 200
 
-      assert(response.body.start_with?("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:PUBLISH\r\nPRODID:-//uk.gov/GOVUK calendars//EN\r\nCALSCALE:GREGORIAN\r\n"))
-      expected_events.each_with_index do |event, _i|
-        expected = ""
-        end_date = (Date.parse(event["date"]) + 1.day).strftime("%Y%m%d")
-        expected << "BEGIN:VEVENT\r\nDTEND;VALUE=DATE:#{end_date}\r\nDTSTART;VALUE=DATE:#{event['date']}\r\nSUMMARY:#{event['title']}\r\n"
-        assert(response.body.include?(expected))
+        expected_non_scottish_events = [
+          { "date" => "20120102", "title" => I18n.t('bank_holidays.new_year') },
+          { "date" => "20120604", "title" => I18n.t('bank_holidays.spring') },
+          { "date" => "20120827", "title" => I18n.t('bank_holidays.summer') },
+        ]
+
+        expected_scottish_events = [
+          { "date" => "20120103", "title" => I18n.t('bank_holidays.new_year') },
+          { "date" => "20120604", "title" => I18n.t('bank_holidays.spring') },
+          { "date" => "20120806", "title" => I18n.t('bank_holidays.summer') },
+        ]
+
+        common_expected_events = [
+          { "date" => "20120605", "title" => I18n.t('bank_holidays.queen_diamond') },
+          { "date" => "20121225", "title" => I18n.t('bank_holidays.christmas') },
+          { "date" => "20121226", "title" => I18n.t('bank_holidays.boxing_day') },
+          { "date" => "20130101", "title" => I18n.t('bank_holidays.new_year') },
+          { "date" => "20130329", "title" => I18n.t('bank_holidays.good_friday') },
+          { "date" => "20131225", "title" => I18n.t('bank_holidays.christmas') },
+          { "date" => "20131226", "title" => I18n.t('bank_holidays.boxing_day') },
+        ]
+
+        expected_events = if calendar.include?("scotland")
+                            expected_scottish_events + common_expected_events
+                          else
+                            expected_non_scottish_events + common_expected_events
+                          end
+
+        assert(
+          response.body.start_with?(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nMETHOD:PUBLISH\r\nPRODID:-//uk.gov/GOVUK calendars//EN\r\nCALSCALE:GREGORIAN\r\n"
+          )
+        )
+
+        assert_equal "text/calendar", response.content_type
+        assert_equal "max-age=86400, public", response.headers["Cache-Control"]
+
+        expected_events.each do |event|
+          end_date = (Date.parse(event["date"]) + 1.day).strftime("%Y%m%d")
+          expected = "BEGIN:VEVENT\r\nDTEND;VALUE=DATE:#{end_date}\r\nDTSTART;VALUE=DATE:#{event['date']}\r\nSUMMARY:#{event['title']}\r\n"
+
+          assert(response.body.include?(expected))
+        end
       end
-      assert(response.body.end_with?("END:VCALENDAR\r\n"))
-
-      assert_equal "text/calendar", response.content_type
-      assert_equal "max-age=86400, public", response.headers["Cache-Control"]
     end
 
     should "have redirect for old 'ni' division" do


### PR DESCRIPTION
Finding Things has been working on migrating related links, part of that work was to replace the breadcrumbs on a number of different frontend applications like:

- calendars
- calculators
- business-support-finder
- frontend
- licence-finder
- smart-answers

That work has already been done, this commit aims to clean up things we
have missed during the migration.

This includes

- upgrading Slimmer to 10.0.0
- deletion of govuk-component-helpers.scss
- rename [Slimmer::SharedTemplates to Slimmer::GovukComponents](https://github.com/alphagov/slimmer/pull/173)
- [remove I18n to build the ics calendar](https://github.com/alphagov/calendars/pull/127/commits/241ce1c83d55d6ee24dc5d91a5e46dfd9752b389)

## Welsh Calendar

<img width="580" alt="screen shot 2016-12-02 at 12 24 39" src="https://cloud.githubusercontent.com/assets/136777/20833993/74963e86-b88a-11e6-9e41-78c20fa6f868.png">


Trello: https://trello.com/c/5Utjs9qw/300-related-links-cleanup