### PR TITLE
Register routes via publishing-api instead of panopticon

### DIFF
--- a/app/presenters/calendar_content_item.rb
+++ b/app/presenters/calendar_content_item.rb
@@ -23,14 +23,14 @@ class CalendarContentItem
       title: calendar.title,
       base_path: base_path,
       document_type: 'calendar',
-      schema_name: 'placeholder_calendar',
+      schema_name: 'generic',
       publishing_app: 'calendars',
       rendering_app: 'calendars',
       locale: 'en',
       details: {},
       public_updated_at: Time.current.to_datetime.rfc3339,
       routes: [
-        { type: 'exact', path: base_path }
+        { type: 'prefix', path: base_path }
       ]
     }
   end

--- a/lib/registerable_calendar.rb
+++ b/lib/registerable_calendar.rb
@@ -31,11 +31,13 @@ class RegisterableCalendar
     [@calendar.need_id.to_s]
   end
 
+  # Sending an empty array for `paths` and `prefixes` will make sure we don't
+  # register routes in Panopticon.
   def paths
-    ["/#{@slug}.json"]
+    []
   end
 
   def prefixes
-    ["/#{@slug}"]
+    []
   end
 end

--- a/test/unit/panopticon_registration_test.rb
+++ b/test/unit/panopticon_registration_test.rb
@@ -17,8 +17,8 @@ class PanopticonRegistrationTest < ActiveSupport::TestCase
         assert ! artefact[key].nil?, "Attribute #{key} is nil"
       end
 
-      assert_equal ["/bank-holidays.json"], artefact[:paths]
-      assert_equal ["/bank-holidays"], artefact[:prefixes]
+      assert_equal [], artefact[:paths]
+      assert_equal [], artefact[:prefixes]
 
       assert_equal 'live', artefact[:state], "Is not live"
     end

--- a/test/unit/presenters/calendar_content_item_test.rb
+++ b/test/unit/presenters/calendar_content_item_test.rb
@@ -9,7 +9,7 @@ class CalendarContentItemTest < ActiveSupport::TestCase
 
     payload = CalendarContentItem.new(calendar).payload
 
-    assert_valid_against_schema payload, 'placeholder'
+    assert_valid_against_schema payload, 'generic'
   end
 
   def test_payload_contains_correct_data

--- a/test/unit/services/calendar_publisher_test.rb
+++ b/test/unit/services/calendar_publisher_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class CalendarPublisherTest < ActiveSupport::TestCase
   def test_publishing_to_publishing_api
-    Services.publishing_api.expects(:put_content).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2", valid_payload_for('placeholder'))
+    Services.publishing_api.expects(:put_content).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2", valid_payload_for('generic'))
     Services.publishing_api.expects(:publish).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2", 'minor')
 
     calendar = Calendar.find('bank-holidays')


### PR DESCRIPTION
This PR makes this application register its routes via the publishing-api instead of content-store.

It's part of the mainstream preparatory work to remove routing from panopticon.

https://trello.com/c/6eOYmUnL/1-register-routes-via-the-publishing-api-for-publisher-formats