### PR TITLE
Use tinsel automatically at Christmas and New Year

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -148,6 +148,12 @@ table.clocks-calendar .equal-width {
     }
   }
 
+  .epic-bunting.tinsel {
+    span {
+      background-image: image-url("tinsel.png");
+    }
+  }
+
   .related {
     margin-top: 4.5em;
 

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -45,6 +45,14 @@ class Calendar
     divisions.any?(&:show_bunting?)
   end
 
+  def bunting_styles
+    if [1, 12].include? Date.today.month
+      'tinsel'
+    else
+      ''
+    end
+  end
+
   def as_json(_options = nil)
     divisions.each_with_object({}) do |division, hash|
       hash[I18n.t(division.slug)] = division.as_json

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => "calendar_head" %>
 
 <% if @calendar.show_bunting? %>
-  <div class="epic-bunting"><span></span></div>
+  <div class="epic-bunting <%= @calendar.bunting_styles %>"><span></span></div>
 <% end %>
 
 <main id="content" role="main" class="group">

--- a/test/integration/bank_holidays_test.rb
+++ b/test/integration/bank_holidays_test.rb
@@ -176,7 +176,7 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
 
   context "showing bunting on bank holidays" do
     should "show bunting when today is a buntable bank holiday" do
-      Timecop.travel(Date.parse("2nd Jan 2012")) do
+      Timecop.travel(Date.parse("9th April 2012")) do
         visit "/bank-holidays"
         assert page.has_css?('.epic-bunting')
         assert page.has_css?('#wrapper.bunted')
@@ -196,6 +196,25 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
         visit "/bank-holidays"
         assert page.has_no_css?('.epic-bunting')
         assert page.has_no_css?('#wrapper.bunted')
+      end
+    end
+
+    should "not use tinsel bunting in the middle of the year" do
+      Timecop.travel(Date.parse("9th April 2012")) do
+        visit "/bank-holidays"
+        assert page.has_no_css?('.tinsel')
+      end
+    end
+
+    should "use tinsel bunting for Christmas and New Year bank holidays" do
+      Timecop.travel(Date.parse("25th December 2012")) do
+        visit "/bank-holidays"
+        assert page.has_css?('.epic-bunting.tinsel')
+      end
+
+      Timecop.travel(Date.parse("2nd Jan 2012")) do
+        visit "/bank-holidays"
+        assert page.has_css?('.epic-bunting.tinsel')
       end
     end
   end # within #content


### PR DESCRIPTION
For the past few years @rjw1 and I have had a little Christmas tradition of devopsing a change in production to use the tinsel bunting on the bank holidays page over Christmas and New Year.

As part of our valiant quest to automate ourselves out of a job, it turns out that these days computers can even do that for us.

Progress, hey?