### PR TITLE
Add bank holidays for 2018

### DIFF
--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -312,6 +312,56 @@
                 "bunting": true
               }
             ],
+            "2018": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "30/03/2018",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.easter_monday",
+                "date": "02/04/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "07/05/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "28/05/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.late_august",
+                "date": "27/08/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "25/12/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "26/12/2018",
+                "notes": "",
+                "bunting": true
+              }
+            ],
             "slug": "common.nations.england-and-wales_slug",
             "title": "common.nations.england-and-wales"
         },
@@ -654,6 +704,62 @@
               {
                 "title": "bank_holidays.boxing_day",
                 "date": "26/12/2017",
+                "notes": "",
+                "bunting": true
+              }
+            ],
+            "2018": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.2nd_january",
+                "date": "02/01/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "30/03/2018",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "07/05/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "28/05/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.summer",
+                "date": "06/08/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.st_andrew",
+                "date": "30/11/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "25/12/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "26/12/2018",
                 "notes": "",
                 "bunting": true
               }
@@ -1036,6 +1142,68 @@
               {
                 "title": "bank_holidays.boxing_day",
                 "date": "26/12/2017",
+                "notes": "",
+                "bunting": true
+              }
+            ],
+            "2018": [
+              {
+                "title": "bank_holidays.new_year",
+                "date": "01/01/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.st_patrick",
+                "date": "19/03/2018",
+                "notes": "common.substitute_day",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.good_friday",
+                "date": "30/03/2018",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.easter_monday",
+                "date": "02/04/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.early_may",
+                "date": "07/05/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.spring",
+                "date": "28/05/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.battle_boyne",
+                "date": "12/07/2018",
+                "notes": "",
+                "bunting": false
+              },
+              {
+                "title": "bank_holidays.late_august",
+                "date": "27/08/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.christmas",
+                "date": "25/12/2018",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "bank_holidays.boxing_day",
+                "date": "26/12/2018",
                 "notes": "",
                 "bunting": true
               }

--- a/lib/data/when-do-the-clocks-change.json
+++ b/lib/data/when-do-the-clocks-change.json
@@ -6,18 +6,6 @@
   "indexable_content": "This clock change gives the UK an extra hour of daylight (sometimes called Daylight Saving Time). From March to October (when the clocks are 1 hour ahead) the UK is on British Summer Time (BST). From October to March, the UK is on Greenwich Mean Time (GMT).",
   "divisions": {
     "united-kingdom": {
-      "2015": [
-        {
-          "title": "Start of British Summer Time",
-          "date": "29/03/2015",
-          "notes": "Clocks go forward one hour"
-        },
-        {
-          "title": "End of British Summer Time",
-          "date": "25/10/2015",
-          "notes": "Clocks go back one hour"
-        }
-      ],
       "2016": [
         {
           "title": "Start of British Summer Time",
@@ -39,6 +27,18 @@
         {
           "title": "End of British Summer Time",
           "date": "29/10/2017",
+          "notes": "Clocks go back one hour"
+        }
+      ],
+      "2018": [
+        {
+          "title": "Start of British Summer Time",
+          "date": "25/03/2018",
+          "notes": "Clocks go forward one hour"
+        },
+        {
+          "title": "End of British Summer Time",
+          "date": "28/10/2017",
           "notes": "Clocks go back one hour"
         }
       ]


### PR DESCRIPTION
Add the generated JSON data for 2018 bank holidays, following the instructions in the README.

See https://github.com/alphagov/calendars/issues/131