### PR TITLE
Add heroku preview deployment script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby File.read(".ruby-version").chomp
+
 gem 'rails', '~> 4.2.7'
 gem 'rails-i18n', '4.0.8'
 

--- a/README.md
+++ b/README.md
@@ -79,11 +79,31 @@ Holidays are announced there 6 months to one year in advance, usually between th
 
 ### Running the application
 
-`bundle exec bowl calendar www`
+When you are in Development:
+
+`bundle exec bowl calendars www`
 
 ### Running the test suite
 
 `bundle exec rake`
+
+### Deploying a preview to Heroku
+
+Start by creating a GitHub pull request with the changes you want to deploy.
+
+Make a note of the pull request number and use the `startup_heroku.sh` script to deploy your changes to Heroku:
+
+```bash
+$ PR=<number-of-pull-request> ./startup_heroku.sh
+```
+
+This script will create and configure an app on Heroku, push the __current branch__ and open the marriage-abroad Smart Answer in the browser.
+
+Once deployed you'll need to use the standard `git push` mechanism to deploy your changes.
+
+```bash
+./startup_heroku.sh
+```
 
 ## Licence
 

--- a/startup_heroku.sh
+++ b/startup_heroku.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+if [ -z "$PR" ];
+then
+  echo "Usage: PR=<pull-request-number> ./startup_heroku.sh"
+  exit 1
+fi
+
+export APP_NAME="calendars-pr-$PR"
+export HEROKU_REMOTE="heroku-$APP_NAME"
+
+echo
+echo "# Creating a new Heroku App"
+echo
+heroku apps:create --region eu --remote $HEROKU_REMOTE $APP_NAME
+
+echo
+echo "# Configuring Heroku ready for Calendars"
+echo
+heroku config:set \
+--app $APP_NAME \
+GOVUK_APP_DOMAIN=integration.publishing.service.gov.uk \
+PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api \
+PLEK_SERVICE_STATIC_URI=https://assets-origin.integration.publishing.service.gov.uk/ \
+RUNNING_ON_HEROKU=true \
+EXPOSE_GOVSPEAK=true \
+ERRBIT_ENV=integration
+
+echo
+echo "# Pushing the current branch to Heroku's master"
+echo
+export CURRENT_BRANCH_NAME=`git branch | grep "^\*" | cut -d" " -f2`
+git push $HEROKU_REMOTE $CURRENT_BRANCH_NAME:master
+
+echo
+echo "# Opening Calendars"
+echo "*NOTE.* You may have to refresh as the app can be slow to start"
+echo
+export HEROKU_URL=`heroku apps:info --app $APP_NAME | grep "Web URL" | cut -c16-`
+export CALENDAR_TO_OPEN="bank-holidays"
+open $HEROKU_URL$CALENDAR_TO_OPEN
+
+echo
+echo "*Set ERRBIT_API_KEY and ERRBIT_HOST manually to enable error reporting*"
+echo "*You can find those key values on https://errbit.<environment>.publishing.service.gov.uk*"
+echo "All done"
+echo


### PR DESCRIPTION
To get a working preview of changes before merging into master, we can deploy the branch to Heroku using this script. It is a modified version of the same script as used in

https://github.com/alphagov/smart-answers/blob/master/startup_heroku.sh

Readme has instructions as taken from

https://github.com/alphagov/smart-answers/blob/master/doc/factcheck.md

Heroku only supports reading the ruby version from the Gemfile. It otherwise defaults to an older version of ruby, that is incompatible with some of the gems being used.