### PR TITLE
Remove more things related to panopticon

### DIFF
--- a/lib/registerable_calendar.rb
+++ b/lib/registerable_calendar.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 class RegisterableCalendar
   extend Forwardable
 
-  attr_accessor :calendar, :slug, :live
+  attr_accessor :calendar, :slug
 
   def_delegators :@calendar, :indexable_content, :content_id
 
@@ -19,23 +19,5 @@ class RegisterableCalendar
 
   def description
     I18n.t(@calendar.description)
-  end
-
-  def state
-    'live'
-  end
-
-  def need_ids
-    [@calendar.need_id.to_s]
-  end
-
-  # Sending an empty array for `paths` and `prefixes` will make sure we don't
-  # register routes in Panopticon.
-  def paths
-    []
-  end
-
-  def prefixes
-    []
   end
 end

--- a/lib/registerable_calendar.rb
+++ b/lib/registerable_calendar.rb
@@ -1,7 +1,5 @@
 require 'ostruct'
 
-# Takes a path and produces a calendar object for registering in
-# panopticon
 class RegisterableCalendar
   extend Forwardable
 


### PR DESCRIPTION
This class used to be used by both panopticon and rummager. Now that panopticon is removed as a dependency (#135) these methods aren't necessary anymore.

https://trello.com/c/7u8M6zrg