### PR TITLE
Remove redundant tag for removing breadcrumb

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,6 @@
     <% end %>
   </head>
   <body class="mainstream">
-    <div class="header-context"><!-- Deliberately empty. This will prevent Slimmer from adding the artefact-breadcrumb. --></div>
     <div id="wrapper" class="answer <%= yield :wrapper_class %>">
       <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
       <div class="grid-row">


### PR DESCRIPTION
This app uses the GOV.UK Component to render the breadcrumb. The tag removed in this was previously necessary to instruct Slimmer to hide the old breadcrumb. We no longer need it because the CSS and HTML have been completely removed from static in https://github.com/alphagov/static/pull/879.

https://trello.com/c/7wohUbyo