### PR TITLE
Add a Jenkinsfile for calendars

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,53 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'calendars'
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  try {
+    stage('Checkout') {
+      checkout scm
+      govuk.cleanupGit()
+      govuk.mergeMasterBranch()
+      govuk.contentSchemaDependency()
+      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
+      govuk.setEnvar("DISPLAY", ":99")
+    }
+
+    stage('Bundle') {
+      govuk.bundleApp()
+    }
+
+    stage('Linter') {
+      govuk.rubyLinter()
+    }
+
+    stage("Assets") {
+      govuk.precompileAssets()
+    }
+
+    stage('Tests') {
+      govuk.runTests()
+    }
+
+    if (env.BRANCH_NAME == 'master') {
+      stage('Push release tag') {
+        govuk.pushTag(REPOSITORY, BRANCH_NAME, 'release_' + BUILD_NUMBER)
+      }
+
+      stage('Deploy to Integration') {
+        // Deploy on Integration (only master)
+        govuk.deployIntegration(REPOSITORY, BRANCH_NAME, 'release', 'deploy')
+      }
+    }
+
+  } catch (e) {
+    currentBuild.result = 'FAILED'
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}


### PR DESCRIPTION
The old ci environment is being turned off, so we need to
start building calendars on the new Jenkins version 2
environment.

The new Jenkinsfile builds the code in branches, and runs
the tests against them in the same manner as the
previous jenkins.sh script.