### PR TITLE
Add build parameters for content schema tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,35 @@
 #!/usr/bin/env groovy
 
 REPOSITORY = 'calendars'
+DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
+  properties([
+    [$class: 'ParametersDefinitionProperty',
+      parameterDefinitions: [
+        [$class: 'BooleanParameterDefinition',
+          name: 'IS_SCHEMA_TEST',
+          defaultValue: false,
+          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
+        [$class: 'StringParameterDefinition',
+          name: 'SCHEMA_BRANCH',
+          defaultValue: DEFAULT_SCHEMA_BRANCH,
+          description: 'The branch of govuk-content-schemas to test against']]
+    ],
+  ])
+
   try {
+    govuk.initializeParameters([
+      'IS_SCHEMA_TEST': 'false',
+      'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
+    ])
+
+    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
+      return
+    }
+    
     stage('Checkout') {
       checkout scm
       govuk.cleanupGit()


### PR DESCRIPTION
[Trello card](https://trello.com/c/58ZBYYGL/564-add-applications-to-downstream-content-schema-test)

 
## Description 

Parameterize build so that branches can be built as usual, but
deployed-to-production can be triggered whenever a change is pushed to a
govuk-content-schemas branch.