### PR TITLE
Bump slimmer to use Rails' cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'uglifier', '2.7.2'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '10.0.0'
+  gem 'slimmer', '10.1.1'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (10.0.0)
+    slimmer (10.1.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -269,7 +269,7 @@ DEPENDENCIES
   shoulda (= 3.5.0)
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 10.0.0)
+  slimmer (= 10.1.1)
   timecop (= 0.8.0)
   uglifier (= 2.7.2)
   unicorn (~> 5.0.0)

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -3,10 +3,6 @@
 Calendars::Application.configure do
   config.slimmer.logger = Rails.logger
 
-  if Rails.env.production?
-    config.slimmer.use_cache = true
-  end
-
   if Rails.env.development?
     config.slimmer.asset_host = ENV["STATIC_DEV"] || "http://static.dev.gov.uk"
   end


### PR DESCRIPTION
This bumps slimmer to make it use the rails cache and send a user agent:

- https://github.com/alphagov/slimmer/pull/184
- https://github.com/alphagov/slimmer/pull/183

It will prevent this app from making many needless requests to `static`.

https://trello.com/c/D9HmkJwI