### PR TITLE
Register document type with Rummager

### DIFF
--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -24,7 +24,8 @@ class SearchPayloadPresenter
       title: title,
       description: description,
       indexable_content: indexable_content,
-      link: "/#{slug}"
+      link: "/#{slug}",
+      content_store_document_type: 'calendar',
     }
   end
 end

--- a/test/unit/services/search_indexer_test.rb
+++ b/test/unit/services/search_indexer_test.rb
@@ -16,6 +16,7 @@ class SearchIndexerTest < ActiveSupport::TestCase
       description:  "Find out when bank holidays are in England, Wales, Scotland and Northern Ireland - including past and future bank holidays",
       indexable_content: "",
       link: '/bank-holidays',
+      content_store_document_type: 'calendar',
     )
 
     SearchIndexer.call(registerable_calendar)


### PR DESCRIPTION
This change will register the document type in Rummager, so that calendar documents can be found by type.

This is useful for [finding mainstream content](https://trello.com/c/5wrs1iHn/432-load-mainstream-links-from-search-for-the-prototype).


### Trello



https://trello.com/c/bRXYo6XY/433-update-mainstream-publishing-apps