### PR TITLE
Improve handling of invalid divisions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,5 @@ require File.expand_path('../config/application', __FILE__)
 require 'ci/reporter/rake/minitest' if Rails.env.test?
 
 Rails.application.load_tasks
+
+task default: [:lint]

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -74,7 +74,7 @@ private
 
   def handle_bank_holiday_ics_calendars
     if scope == "bank-holidays"
-      division_slug = Calendar::Division::SLUGS.fetch(params[:division])
+      division_slug = Calendar::Division::SLUGS[params[:division]]
 
       params[:division] = "common.nations.#{division_slug}"
     end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,5 @@
+desc "Run govuk-lint with similar params to CI"
+task "lint" do
+  sh "govuk-lint-ruby --format clang Gemfile app lib test"
+  sh "govuk-lint-sass app"
+end

--- a/test/integration/icalendar_test.rb
+++ b/test/integration/icalendar_test.rb
@@ -73,5 +73,10 @@ class IcalendarTest < ActionDispatch::IntegrationTest
       assert_equal 301, response.status
       assert_equal "http://www.example.com/bank-holidays/northern-ireland.ics", response.location
     end
+
+    should "404 if the division does not exist" do
+      get "/bank-holidays/never-never-land.ics"
+      assert_equal 404, response.status
+    end
   end
 end


### PR DESCRIPTION
We're getting quite a few requests for paths like /bank-holidays/england-and-wales-2012.ics on Production. These have an invalid division which causes a KeyError.  These have tripped our Fastly 5xx alerts for GOV.UK a few times today, but they're not real pages (at least not any more).

Example: https://errbit.publishing.service.gov.uk/apps/536119100da1151271001052/problems/58aebe536578632b11500200

We should handle these requests with a 404 instead.

I've also added the linter to the default rake task.