### PR TITLE
Re-bundle with new ruby and bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,5 +275,8 @@ DEPENDENCIES
   unicorn (~> 5.0.0)
   webmock (= 1.24.2)
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.13.1
+   1.14.5


### PR DESCRIPTION
This puts a RUBY_VERSION and updates BUNDLED_WITH to the correct version
as per our puppet infrastructure.  Having these left out means useful
scripts in the development VM won't run on this repo because of
uncommitted local changes.