### PR TITLE
Remove 2016 clock changes and correcting 2018

### DIFF
--- a/lib/data/when-do-the-clocks-change.json
+++ b/lib/data/when-do-the-clocks-change.json
@@ -6,18 +6,6 @@
   "indexable_content": "This clock change gives the UK an extra hour of daylight (sometimes called Daylight Saving Time). From March to October (when the clocks are 1 hour ahead) the UK is on British Summer Time (BST). From October to March, the UK is on Greenwich Mean Time (GMT).",
   "divisions": {
     "united-kingdom": {
-      "2016": [
-        {
-          "title": "Start of British Summer Time",
-          "date": "27/03/2016",
-          "notes": "Clocks go forward one hour"
-        },
-        {
-          "title": "End of British Summer Time",
-          "date": "30/10/2016",
-          "notes": "Clocks go back one hour"
-        }
-      ],
       "2017": [
         {
           "title": "Start of British Summer Time",
@@ -38,7 +26,7 @@
         },
         {
           "title": "End of British Summer Time",
-          "date": "28/10/2017",
+          "date": "28/10/2018",
           "notes": "Clocks go back one hour"
         }
       ]


### PR DESCRIPTION
[Trello card](https://trello.com/c/WOPjWoSa)

Removed 2016 because it's in the past and corrected 28/10/2017 to 28/10/2018.

Supersedes #144 

## Before
![image](https://user-images.githubusercontent.com/424772/27091643-a88b6124-5058-11e7-86df-64c5bef832a7.png)

## After
![image](https://user-images.githubusercontent.com/424772/27091663-b2340e92-5058-11e7-95c9-92b77c031823.png)
