### PR TITLE
Send update type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 46.0.0'
+  gem 'gds-api-adapters', '~> 47.2'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (46.0.0)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -266,7 +266,7 @@ DEPENDENCIES
   airbrake!
   capybara (= 2.14.0)
   ci_reporter_minitest (= 1.0.0)
-  gds-api-adapters (~> 46.0.0)
+  gds-api-adapters (~> 47.2)
   govuk-content-schema-test-helpers (~> 1.4.0)
   govuk-lint (= 0.8.1)
   govuk_frontend_toolkit (~> 6.0.3)

--- a/app/presenters/calendar_content_item.rb
+++ b/app/presenters/calendar_content_item.rb
@@ -31,7 +31,8 @@ class CalendarContentItem
       public_updated_at: Time.current.to_datetime.rfc3339,
       routes: [
         { type: 'prefix', path: base_path }
-      ]
+      ],
+      update_type: update_type,
     }
   end
 end

--- a/app/services/calendar_publisher.rb
+++ b/app/services/calendar_publisher.rb
@@ -5,7 +5,7 @@ class CalendarPublisher
 
   def publish
     Services.publishing_api.put_content(rendered.content_id, rendered.payload)
-    Services.publishing_api.publish(rendered.content_id, rendered.update_type)
+    Services.publishing_api.publish(rendered.content_id)
   end
 
 private

--- a/test/unit/services/calendar_publisher_test.rb
+++ b/test/unit/services/calendar_publisher_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class CalendarPublisherTest < ActiveSupport::TestCase
   def test_publishing_to_publishing_api
     Services.publishing_api.expects(:put_content).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2", valid_payload_for('generic'))
-    Services.publishing_api.expects(:publish).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2", 'minor')
+    Services.publishing_api.expects(:publish).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2")
 
     calendar = Calendar.find('bank-holidays')
 


### PR DESCRIPTION
Sending it on publish has been deprecated in favour of including it when sending a put content.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)