### PR TITLE
Don't report certain `GdsApi` errors to Sentry

### DIFF
--- a/config/initializers/govuk_app_config.rb
+++ b/config/initializers/govuk_app_config.rb
@@ -1,0 +1,5 @@
+GovukError.configure do |config|
+  config.excluded_exceptions << "GdsApi::TimedOutException"
+  config.excluded_exceptions << "GdsApi::HTTPBadGateway"
+  config.excluded_exceptions << "GdsApi::HTTPGatewayTimeout"
+end


### PR DESCRIPTION
As per https://docs.publishing.service.gov.uk/manual/errors.html, these errors are "Intermittent retryable" and shouldn't be reported to Sentry because they aren't actionable.