### PR TITLE
Set primary publishing organisation

### DIFF
--- a/app/presenters/calendar_content_item.rb
+++ b/app/presenters/calendar_content_item.rb
@@ -1,5 +1,7 @@
 # Renders a calendar for the publishing-api.
 class CalendarContentItem
+  GDS_ORGANISATION_ID = "af07d5a5-df63-4ddc-9383-6a666845ebe9".freeze
+
   attr_reader :calendar
 
   def initialize(calendar)
@@ -36,6 +38,12 @@ class CalendarContentItem
         { type: 'prefix', path: base_path }
       ],
       update_type: update_type,
+    }
+  end
+
+  def links
+    {
+      "primary_publishing_organisation": [GDS_ORGANISATION_ID]
     }
   end
 end

--- a/app/services/calendar_publisher.rb
+++ b/app/services/calendar_publisher.rb
@@ -6,6 +6,7 @@ class CalendarPublisher
   def publish
     Services.publishing_api.put_content(rendered.content_id, rendered.payload)
     Services.publishing_api.publish(rendered.content_id)
+    Services.publishing_api.patch_links(rendered.content_id, links: rendered.links)
   end
 
 private

--- a/test/unit/services/calendar_publisher_test.rb
+++ b/test/unit/services/calendar_publisher_test.rb
@@ -4,6 +4,7 @@ class CalendarPublisherTest < ActiveSupport::TestCase
   def test_publishing_to_publishing_api
     Services.publishing_api.expects(:put_content).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2", valid_payload_for('calendar'))
     Services.publishing_api.expects(:publish).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2")
+    Services.publishing_api.expects(:patch_links).with("58f79dbd-e57f-4ab2-ae96-96df5767d1b2", links: { primary_publishing_organisation: ["af07d5a5-df63-4ddc-9383-6a666845ebe9"] })
 
     calendar = Calendar.find('bank-holidays')
 


### PR DESCRIPTION
GDS is the primary publishing organisation for calendars, because there is no publishing app for them. They are just 2 json files on github.

We are going to set a primary organisation for all content items so that we can group and report on content better.

2 down, 534371 to go....

Trello:
- https://trello.com/c/BNMbxdAO/365-placeholder-set-primary-org-for-calendar
- https://trello.com/c/DFvcvGGX/366-republish-calendar-documents