### PR TITLE
Remove Slimmer::GovukComponents

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@ require "gds_api/helpers"
 
 class ApplicationController < ActionController::Base
   include Slimmer::Template
-  include Slimmer::GovukComponents
 
   protect_from_forgery with: :exception
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,8 +24,6 @@ Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 
 class ActiveSupport::TestCase
   setup do
-    stub_request(:get, %r{#{Plek.new.find("static")}/templates/locales/(en|cy)})
-      .to_return(body: {}.to_json)
     I18n.locale = :en
   end
 


### PR DESCRIPTION
This app isn't consuming any Static-based components anymore, so we don't need to include this and the test helper.