### PR TITLE
Use title component for page headings

### DIFF
--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -5,11 +5,7 @@
 <% end %>
 
 <main id="content" role="main" class="group">
-  <header class="page-header group">
-    <div>
-      <h1><%=@calendar.title %></h1>
-    </div>
-  </header>
+  <%= render "govuk_publishing_components/components/title", title: @calendar.title %>
 
   <div class="article-container group">
 

--- a/app/views/calendar/when_do_the_clocks_change.html.erb
+++ b/app/views/calendar/when_do_the_clocks_change.html.erb
@@ -1,11 +1,7 @@
 <%= render :partial => "calendar_head" %>
 
 <main id="content" role="main" class="group">
-  <header class="page-header group">
-    <div>
-      <h1><%= @calendar.title %></h1>
-    </div>
-  </header>
+  <%= render "govuk_publishing_components/components/title", title: @calendar.title %>
 
   <div class="article-container group">
     <article role="article" class="group">


### PR DESCRIPTION
Using this component means we use less global CSS from Static, which means deprecating it will be easier.

https://trello.com/c/k5LKbs2g