### PR TITLE
Move Early May Bank Holiday 2020

### DIFF
--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -433,7 +433,7 @@
                 },
                 {
                     "title": "bank_holidays.early_may",
-                    "date": "04/05/2020",
+                    "date": "08/05/2020",
                     "notes": "",
                     "bunting": true
                 },
@@ -1509,7 +1509,7 @@
                 },
                 {
                     "title": "bank_holidays.early_may",
-                    "date": "04/05/2020",
+                    "date": "08/05/2020",
                     "notes": "",
                     "bunting": true
                 },


### PR DESCRIPTION
It was announced that the early May bank holiday in 2020 will move from
Monday 4 May to Friday 8 May to mark the 75th anniversary of VE Day.

https://www.gov.uk/government/news/2020-may-bank-holiday-will-be-moved-to-mark-75th-anniversary-of-ve-day