### PR TITLE
Update early May bank holiday 2020 to include VE day

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -36,6 +36,7 @@ cy:
     good_friday:   "Dydd Gwener y Groglith"
     easter_monday: "Dydd Llun y Pasg"
     early_may:     "Gŵyl Banc Cyntaf Mai"
+    early_may_ve:  "Gŵyl Banc Cyntaf Mai (VE day)"
     spring:        "Gŵyl Banc y Gwanwyn"
     battle_boyne:  "Brwydr y Boyne (Diwrnod yr Orangemen)"
     summer:        "Gŵyl Banc yr Haf"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
     good_friday:    "Good Friday"
     easter_monday:  "Easter Monday"
     early_may:      "Early May bank holiday"
+    early_may_ve:   "Early May bank holiday (VE day)"
     spring:         "Spring bank holiday"
     battle_boyne:   "Battle of the Boyne (Orangemen’s Day)"
     summer:         "Summer bank holiday"

--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -432,8 +432,8 @@
                     "bunting": true
                 },
                 {
-                    "title": "bank_holidays.early_may",
-                    "date": "04/05/2020",
+                    "title": "bank_holidays.early_may_ve",
+                    "date": "08/05/2020",
                     "notes": "",
                     "bunting": true
                 },
@@ -1508,8 +1508,8 @@
                     "bunting": true
                 },
                 {
-                    "title": "bank_holidays.early_may",
-                    "date": "04/05/2020",
+                    "title": "bank_holidays.early_may_ve",
+                    "date": "08/05/2020",
                     "notes": "",
                     "bunting": true
                 },


### PR DESCRIPTION
The early May bank holiday 2020 is moving from 04 May to 08 May to mark
the 75th anniversary of VE Day for England, Wales and Northern Ireland. Scotland is staying as it was.

Add an entry to the locale files under `bank_holidays.early_may_ve`.
We have no translation for Welsh yet so I've left it as "VE day".

I've chosen to add a new bank holiday to the locales rather than
include `notes` into the existing May bank holiday. This is because we
explicitly want "VE day" to be capitalised and `notes` are
[dowcased](https://github.com/alphagov/calendars/blob/6d51141ea5a50582305d7dc7f6dc1f0b0a85287a/app/views/components/_calendar.html.erb#L18).

Although we could argue that `notes` fields should be represented
verbatim, I discussed the various options with the content team and decided to
leave the current functionality as it was (i.e. anything in the notes
fields will be downcased) rather than remove downcasing from the `notes`
field and introducing a potential regression..

I decided that adding a new locale entry was perhaps neater than an
explicit condition when presenting notes.

This does open up the possibility that we have a notes field filled in
as well for this "new" bank holiday which would then display as:

```
Early May bank holiday (VE day) (more notes).
```

That does seem a bit odd, but we already have this pattern with [Battle
of the Boyne](https://github.com/alphagov/calendars/blob/6d51141ea5a50582305d7dc7f6dc1f0b0a85287a/config/locales/en.yml#L61) for, among others, [2020](https://github.com/alphagov/calendars/blob/6d51141ea5a50582305d7dc7f6dc1f0b0a85287a/lib/data/bank-holidays.json#L1523-L1526).

This does not affect the generation of new bank holidays by way of the
rake task.

[Trello](https://trello.com/c/8bufks24/1057-change-bank-holiday-date-for-may-bank-holiday-2020)