### PR TITLE
Change early May 2020 bank holiday for Scotland

### DIFF
--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -940,8 +940,8 @@
                     "bunting": false
                 },
                 {
-                    "title": "bank_holidays.early_may",
-                    "date": "04/05/2020",
+                    "title": "bank_holidays.early_may_ve",
+                    "date": "08/05/2020",
                     "notes": "",
                     "bunting": true
                 },


### PR DESCRIPTION
This holiday was changed for England, Wales and Northern Ireland in the
following PR: https://github.com/alphagov/calendars/pull/602

This commit also changes the holiday date for Scotland as requested
here: https://govuk.zendesk.com/agent/tickets/3728504