### PR TITLE
 Update govuk_publishing_components to 18.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails-i18n', '~> 5.1.3'
 gem 'json', '~> 2.2.0'
 gem 'plek', '3.0.0'
 
-gem 'govuk_publishing_components', '~> 17.21.0'
+gem 'govuk_publishing_components', '~> 18.0.0'
 
 gem 'rack_strip_client_ip', '0.0.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (17.21.0)
+    govuk_publishing_components (18.0.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -214,7 +214,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.7.0)
+    rouge (3.8.0)
     rubocop (0.72.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -318,7 +318,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6.1)
   govuk-lint (= 3.11.5)
   govuk_app_config (~> 1.20.2)
-  govuk_publishing_components (~> 17.21.0)
+  govuk_publishing_components (~> 18.0.0)
   json (~> 2.2.0)
   mocha (= 1.9.0)
   plek (= 3.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,5 @@
+$govuk-compatibility-govuktemplate: true;
+
 @import "govuk_publishing_components/all_components";
 
 @import "objects/bunting";

--- a/app/assets/stylesheets/objects/_bunting.scss
+++ b/app/assets/stylesheets/objects/_bunting.scss
@@ -2,7 +2,7 @@
   width: 100%;
   height: 50px;
   overflow: visible;
-  border-top: 1px solid govuk-colour("grey-2");
+  border-top: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
   position: absolute;
   left: 0;
 


### PR DESCRIPTION
This PR:
- govuk_publishing_components to 18.0.0
- enables compatibility with `govuk-template` using the following SCSS flag `$govuk-compatibility-govuktemplate: true;`
- updates mixins