### PR TITLE
Update govuk_publishing_components to 22.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "rails-i18n", "~> 5.1.3"
 gem "json", "~> 2.2.0"
 gem "plek", "3.0.0"
 
-gem "govuk_publishing_components", "~> 21.5.0"
+gem "govuk_publishing_components", "~> 21.5.1"
 
 gem "rack_strip_client_ip", "0.0.2"
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,10 @@ gem "rails-i18n", "~> 5.1.3"
 gem "json", "~> 2.2.0"
 gem "plek", "3.0.0"
 
-gem "govuk_publishing_components", "~> 21.5.1"
+gem "govuk_publishing_components", "~> 22.0.0"
 
 gem "rack_strip_client_ip", "0.0.2"
 
-gem "sass-rails", "5.0.7"
 gem "uglifier", "4.2.0"
 
 if ENV["SLIMMER_DEV"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_publishing_components (21.5.0)
+    govuk_publishing_components (21.5.1)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -311,7 +311,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6.1)
   govuk-lint (= 4.0.1)
   govuk_app_config (~> 2.0.1)
-  govuk_publishing_components (~> 21.5.0)
+  govuk_publishing_components (~> 21.5.1)
   json (~> 2.2.0)
   mocha (= 1.9.0)
   plek (= 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_publishing_components (21.5.1)
+    govuk_publishing_components (22.0.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -133,7 +133,7 @@ GEM
     method_source (0.9.2)
     mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0904)
+    mime-types-data (3.2019.1009)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -196,7 +196,7 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     raindrops (0.19.0)
-    rake (12.3.3)
+    rake (13.0.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -208,8 +208,8 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.11.1)
-    rubocop (0.75.0)
+    rouge (3.12.0)
+    rubocop (0.75.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
@@ -228,12 +228,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -242,8 +236,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.58.0)
-      rake (>= 0.9, < 13)
+    scss_lint (0.59.0)
       sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.11.3)
       faraday (>= 0.7.6, < 1.0)
@@ -268,7 +261,7 @@ GEM
       plek (>= 1.1.0)
       rack
       rest-client
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -311,7 +304,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6.1)
   govuk-lint (= 4.0.1)
   govuk_app_config (~> 2.0.1)
-  govuk_publishing_components (~> 21.5.1)
+  govuk_publishing_components (~> 22.0.0)
   json (~> 2.2.0)
   mocha (= 1.9.0)
   plek (= 3.0.0)
@@ -320,7 +313,6 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-controller-testing
   rails-i18n (~> 5.1.3)
-  sass-rails (= 5.0.7)
   shoulda (= 3.6.0)
   simplecov (= 0.17.1)
   simplecov-rcov (= 0.2.3)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,6 @@
+// JS and CSS bundles
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css
+
+// Images and fonts, so that views can link to them
+//= link_tree ../images

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,6 +1,13 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
+
+Rails.application.config.assets.precompile += %w(
+  application.js
+  application.css
+  print.css
+)
+
 Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,6 +1,4 @@
-# Be sure to restart your server when you modify this file.
-
-# Version of your assets, change this if you want to expire all your assets.
+Rails.application.config.assets.precompile += %w(manifest.js)
 
 Rails.application.config.assets.precompile += %w(
   application.js
@@ -9,10 +7,3 @@ Rails.application.config.assets.precompile += %w(
 )
 
 Rails.application.config.assets.version = "1.0"
-
-# Add additional assets to the asset load path
-# Rails.application.config.assets.paths << Emoji.images_path
-
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )


### PR DESCRIPTION
Upgrades to `govuk_publishing_components 22.0.0` which requires `sprockets 4.0` explicit assets declaration and a `manifest.js`

Aligns `config/initializers/assets.rb` and `app/assets/config/manifest.js` declarations with other Rails apps.