### PR TITLE
Rescue 403 errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,15 +19,13 @@ class ApplicationController < ActionController::Base
 
 protected
 
-  def error_403(exception); error(403, exception); end
+  def error_403
+    render status: :forbidden, plain: "403 forbidden"
+  end
 
-  def error_503(exception); error(503, exception); end
-
-  def error(status_code, exception = nil)
-    if exception && defined? GovukError
-      GovukError.notify exception
-    end
-    render status: status_code, plain: "#{status_code} error"
+  def error_503(exception)
+    GovukError.notify(exception) if exception && defined? GovukError
+    render status: :service_unavailable, plain: "503 service unavailable"
   end
 
   def set_expiry(age = 60.minutes)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from GdsApi::TimedOutException, with: :error_503
 
   slimmer_template "core_layout"
@@ -18,13 +19,15 @@ class ApplicationController < ActionController::Base
 
 protected
 
+  def error_403(exception); error(403, exception); end
+
   def error_503(exception); error(503, exception); end
 
   def error(status_code, exception = nil)
     if exception && defined? GovukError
       GovukError.notify exception
     end
-    render status: status_code, text: "#{status_code} error"
+    render status: status_code, plain: "#{status_code} error"
   end
 
   def set_expiry(age = 60.minutes)

--- a/test/functional/calendar_controller_test.rb
+++ b/test/functional/calendar_controller_test.rb
@@ -74,6 +74,14 @@ class CalendarControllerTest < ActionController::TestCase
       get :calendar, params: { scope: "something..etc-passwd" }
       assert_equal 404, response.status
     end
+
+    should "403 if content store returns forbidden response" do
+      stub_request(:get, "#{Plek.find('content-store')}/content/something-access-limited").
+        to_return(status: 403, headers: {})
+
+      get :calendar, params: { scope: "something-access-limited" }
+      assert_equal 403, response.status
+    end
   end
 
   context "GET 'division'" do


### PR DESCRIPTION
Trello: https://trello.com/c/gKND6vZM/169-unauthenticated-user-accessing-a-calendars-page-with-step-by-step-token-is-directed-to-sign-on
Follows on from: [RFC 113: Expanding draft access for unauthenticated users to allow multi-page fact checks](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-113-expanding-draft-access-for-unauthenticated-users.md)

## What's changed and why?

At the moment calendars is throwing a 500 when it receives
an error code it doesn't recognise from content-store. That means
that users are shown a "Problem has occurred" page.

We need to handle this error properly so that in the case of a
403, the user will be properly routed to signon and asked to login
if there is any form of access limiting on the content item (e.g.
hosted on draft stack, access limited to organisation)