### PR TITLE
Update govuk_publishing_components to 21.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "rails-i18n", "~> 5.1.3"
 gem "json", "~> 2.2.0"
 gem "plek", "3.0.0"
 
-gem "govuk_publishing_components", "~> 21.8.1"
+gem "govuk_publishing_components", "~> 21.9.0"
 
 gem "rack_strip_client_ip", "0.0.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_publishing_components (21.8.1)
+    govuk_publishing_components (21.9.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -311,7 +311,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6.1)
   govuk-lint (= 4.2.0)
   govuk_app_config (~> 2.0.1)
-  govuk_publishing_components (~> 21.8.1)
+  govuk_publishing_components (~> 21.9.0)
   json (~> 2.2.0)
   mocha (= 1.9.0)
   plek (= 3.0.0)


### PR DESCRIPTION
Bumps govuk_publishing_components to version 21.9.0. This includes a change which adds a related link to the Brexit landing page on pages tagged to /brexit, /world/brexit, or any child taxon of /brexit.

https://govuk-calendars-pr-709.herokuapp.com/bank-holidays