### PR TITLE
Use `rubocop-govuk` and `scss_lint-govuk` instead of `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    
 Style/CommentedKeyword:
   Exclude:
     - 'test/integration/when_do_the_clocks_change_test.rb'

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,1 @@
+plugin_gems: ['scss_lint-govuk']

--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,9 @@ else
 end
 
 group :test, :development do
-  gem "govuk-lint", "4.2.0"
   gem "pry-byebug"
+  gem "rubocop-govuk"
+  gem "scss_lint-govuk"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,11 +85,6 @@ GEM
       activesupport (>= 4.2.0)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.2.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -217,6 +212,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -245,6 +244,8 @@ GEM
       tilt
     scss_lint (0.59.0)
       sass (~> 3.5, >= 3.5.5)
+    scss_lint-govuk (0.2.0)
+      scss_lint
     sentry-raven (2.11.3)
       faraday (>= 0.7.6, < 1.0)
     shoulda (3.6.0)
@@ -309,7 +310,6 @@ DEPENDENCIES
   ci_reporter_minitest (= 1.0.0)
   gds-api-adapters
   govuk-content-schema-test-helpers (~> 1.6.1)
-  govuk-lint (= 4.2.0)
   govuk_app_config (~> 2.0.1)
   govuk_publishing_components (~> 21.10.0)
   json (~> 2.2.0)
@@ -320,7 +320,9 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-controller-testing
   rails-i18n (~> 5.1.3)
+  rubocop-govuk
   sass-rails (= 5.0.7)
+  scss_lint-govuk
   shoulda (= 3.6.0)
   simplecov (= 0.17.1)
   simplecov-rcov (= 0.2.3)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,5 +1,5 @@
 desc "Run govuk-lint with similar params to CI"
 task "lint" do
-  sh "govuk-lint-ruby --parallel Gemfile app lib test"
-  sh "govuk-lint-sass app"
+  sh "rubocop --parallel Gemfile app lib test"
+  sh "scss-lint app"
 end


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk