### PR TITLE
Switch colours to new higher contrast

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 $govuk-compatibility-govuktemplate: true;
+$govuk-use-legacy-palette: false;
 
 @import "govuk_publishing_components/all_components";
 


### PR DESCRIPTION
GOV.UK Frontend (Design System) version 3 has [better colour contrast](https://designnotes.blog.gov.uk/2019/07/29/weve-updated-the-gov-uk-colours-and-font/), which we're activating here but maintaining the legacy base font size for now. We will address the new base font size in a future PR.

## Screenshots

## Before
![www gov uk_bank-holidays](https://user-images.githubusercontent.com/424772/68868167-f3c55380-06ee-11ea-9804-4d03e7705208.png)


## After
![calendars dev gov uk_bank-holidays](https://user-images.githubusercontent.com/424772/68868179-f88a0780-06ee-11ea-8f8c-f2178b0786f9.png)
