### PR TITLE
Add FAQ metadata to pages

### DIFF
--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -17,6 +17,8 @@ class CalendarController < ApplicationController
           @meta_section = section_name.downcase
         end
 
+        @faq_presenter = FaqPresenter.new(scope, @calendar, @content_item)
+
         render scope.tr("-", "_")
       end
       format.json do

--- a/app/presenters/faq_presenter.rb
+++ b/app/presenters/faq_presenter.rb
@@ -36,15 +36,15 @@ private
   def answer_for(division)
     return nil unless division.upcoming_event
 
+    date = "the #{division.upcoming_event.date.day.ordinalize} of #{division.upcoming_event.date.strftime('%B')}"
+
     case scope
     when "bank-holidays"
-      is_in = I18n.t("common.next_holiday_in_is").sub("%{in_nation}", I18n.t("#{division.title}_in"))
-      day = division.upcoming_event.date == Date.today ? I18n.t("common.today") : I18n.l(division.upcoming_event.date, format: "%e %B")
-      title = I18n.t(division.title)
-      body = "#{is_in} #{day}: #{division.upcoming_event.title}"
+      title = I18n.t(division.title, locale: :en)
+      body = "The next bank holiday in #{title} is #{division.upcoming_event.title} on #{date}"
     when "when-do-the-clocks-change"
       title = content_item[:title]
-      body = "The #{division.upcoming_event.notes.gsub(' one hour', '').downcase} #{division.upcoming_event.date.strftime('%e %B')}"
+      body = "The #{division.upcoming_event.notes.gsub(' one hour', '').downcase} on #{date}"
     else
       raise "Unknown scope"
     end

--- a/app/presenters/faq_presenter.rb
+++ b/app/presenters/faq_presenter.rb
@@ -1,0 +1,65 @@
+class FaqPresenter
+  def initialize(scope, calendar, content_item)
+    @scope = scope
+    @calendar = calendar
+    @content_item = content_item.symbolize_keys
+  end
+
+  def metadata
+    # http://schema.org/FAQPage
+    {
+      "@context" => "http://schema.org",
+      "@type" => "FAQPage",
+      "headline" => content_item[:title],
+      "description" => content_item[:description],
+      "publisher" => {
+        "@type" => "Organization",
+        "name" => "GOV.UK",
+        "url" => "https://www.gov.uk",
+        "logo" => {
+          "@type" => "ImageObject",
+          "url" => logo_url,
+        },
+      },
+      "mainEntity" => questions_and_answers,
+    }
+  end
+
+private
+
+  attr_reader :scope, :calendar, :content_item
+
+  def questions_and_answers
+    calendar.divisions.map { |division| answer_for(division) }.compact
+  end
+
+  def answer_for(division)
+    return nil unless division.upcoming_event
+
+    case scope
+    when "bank-holidays"
+      is_in = I18n.t("common.next_holiday_in_is").sub("%{in_nation}", I18n.t("#{division.title}_in"))
+      day = division.upcoming_event.date == Date.today ? I18n.t("common.today") : I18n.l(division.upcoming_event.date, format: "%e %B")
+      title = I18n.t(division.title)
+      body = "#{is_in} #{day}: #{division.upcoming_event.title}"
+    when "when-do-the-clocks-change"
+      title = content_item[:title]
+      body = "The #{division.upcoming_event.notes.gsub(' one hour', '').downcase} #{division.upcoming_event.date.strftime('%e %B')}"
+    else
+      raise "Unknown scope"
+    end
+
+    {
+      "@type" => "Question",
+      "name" => title,
+      "acceptedAnswer" => {
+        "@type" => "Answer",
+        "text" => body,
+      },
+    }
+  end
+
+  def logo_url
+    Plek.current.asset_root + ActionController::Base.helpers.asset_url("govuk_publishing_components/govuk-logo.png", type: :image)
+  end
+end

--- a/app/views/calendar/_calendar_footer.html.erb
+++ b/app/views/calendar/_calendar_footer.html.erb
@@ -1,0 +1,3 @@
+<script type="application/ld+json">
+  <%= @faq_presenter.metadata.to_json.html_safe %>
+</script>

--- a/app/views/calendar/bank_holidays.html.erb
+++ b/app/views/calendar/bank_holidays.html.erb
@@ -77,3 +77,5 @@
 </main>
 
 <% content_for :related_container_class do %><% if @calendar.show_bunting? -%>app-o-related-container--bunted<% end %><% end %>
+
+<%= render :partial => "calendar_footer" %>

--- a/app/views/calendar/when_do_the_clocks_change.html.erb
+++ b/app/views/calendar/when_do_the_clocks_change.html.erb
@@ -48,3 +48,5 @@
     last_updated: last_updated_date
   } %>
 </main>
+
+<%= render :partial => "calendar_footer" %>

--- a/test/unit/presenters/faq_presenter_test.rb
+++ b/test/unit/presenters/faq_presenter_test.rb
@@ -6,9 +6,9 @@ class FaqPresenterTest < ActiveSupport::TestCase
 
   def test_uses_bank_holiday_body_for_bank_holidays
     expected = [
-      q_and_a("England and Wales", "The next bank holiday in England and Wales is  6 April Good Friday"),
-      q_and_a("Scotland", "The next bank holiday in Scotland is  6 April Good Friday"),
-      q_and_a("Northern Ireland", "The next bank holiday in Northern Ireland is  6 April Good Friday"),
+      q_and_a("England and Wales", "The next bank holiday in England and Wales is Good Friday on the 6th of April"),
+      q_and_a("Scotland", "The next bank holiday in Scotland is Good Friday on the 6th of April"),
+      q_and_a("Northern Ireland", "The next bank holiday in Northern Ireland is Good Friday on the 6th of April"),
     ]
 
     Timecop.travel(Date.parse("2012-03-24")) do
@@ -24,7 +24,7 @@ class FaqPresenterTest < ActiveSupport::TestCase
 
   def test_uses_wdtcc_body_for_wdtcc
     expected = [
-      q_and_a("When do the clocks change?", "The clocks advance 25 March"),
+      q_and_a("When do the clocks change?", "The clocks advance on the 25th of March"),
     ]
 
     Timecop.travel(Date.parse("2012-03-24")) do

--- a/test/unit/presenters/faq_presenter_test.rb
+++ b/test/unit/presenters/faq_presenter_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+require "govuk-content-schema-test-helpers/test_unit"
+
+class FaqPresenterTest < ActiveSupport::TestCase
+  include GovukContentSchemaTestHelpers::TestUnit
+
+  def test_uses_bank_holiday_body_for_bank_holidays
+    expected = [
+      q_and_a("England and Wales", "The next bank holiday in England and Wales is  6 April Good Friday"),
+      q_and_a("Scotland", "The next bank holiday in Scotland is  6 April Good Friday"),
+      q_and_a("Northern Ireland", "The next bank holiday in Northern Ireland is  6 April Good Friday"),
+    ]
+
+    Timecop.travel(Date.parse("2012-03-24")) do
+      scope = "bank-holidays"
+      calendar = Calendar.find(scope)
+      content_item = CalendarContentItem.new(calendar).payload
+
+      presenter = FaqPresenter.new(scope, calendar, content_item)
+
+      assert_equal expected, presenter.metadata["mainEntity"]
+    end
+  end
+
+  def test_uses_wdtcc_body_for_wdtcc
+    expected = [
+      q_and_a("When do the clocks change?", "The clocks advance 25 March"),
+    ]
+
+    Timecop.travel(Date.parse("2012-03-24")) do
+      scope = "when-do-the-clocks-change"
+      calendar = Calendar.find(scope)
+      content_item = CalendarContentItem.new(calendar).payload
+
+      presenter = FaqPresenter.new(scope, calendar, content_item)
+
+      assert_equal expected, presenter.metadata["mainEntity"]
+    end
+  end
+
+private
+
+  def q_and_a(question, answer)
+    {
+      "@type" => "Question",
+      "name" => question,
+      "acceptedAnswer" => {
+        "@type" => "Answer",
+        "text" => answer,
+      },
+    }
+  end
+end


### PR DESCRIPTION
## Bank holidays

<img width="357" alt="Screenshot 2019-11-20 at 15 06 44" src="https://user-images.githubusercontent.com/75235/69250387-79da1200-0ba7-11ea-8e27-7dde42ffb911.png">
<img width="928" alt="Screenshot 2019-11-20 at 15 06 31" src="https://user-images.githubusercontent.com/75235/69250376-747cc780-0ba7-11ea-8f0a-ba39e5d1b1ba.png">

## When do the clocks change?

This one doesn't get a rich result because there's only one question.

<img width="945" alt="Screenshot 2019-11-20 at 15 07 03" src="https://user-images.githubusercontent.com/75235/69250400-80688980-0ba7-11ea-9d67-812ab9d29571.png">

---

[Trello card](https://trello.com/c/4jEs6raZ/1155-faq-scheme-for-uk-bank-holiday-page)
