### PR TITLE
Add a failing test for tinsel not being used in early December

### DIFF
--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -47,7 +47,7 @@ class Calendar
   end
 
   def bunting_styles
-    if [1, 12].include? Time.zone.today.month
+    if christmas? || new_year?
       "tinsel"
     else
       ""
@@ -66,5 +66,13 @@ class Calendar
 
   def body
     @data["body"]
+  end
+
+  def christmas?
+    Time.zone.today.month == 12 && (25..28).include?(Time.zone.today.day)
+  end
+
+  def new_year?
+    Time.zone.today.month == 1 && (1..4).include?(Time.zone.today.day)
   end
 end

--- a/test/integration/bank_holidays_test.rb
+++ b/test/integration/bank_holidays_test.rb
@@ -194,6 +194,14 @@ class BankHolidaysTest < ActionDispatch::IntegrationTest
       end
     end
 
+    should "not use tinsel bunting for bank holidays in early December" do
+      # For example, on a substitute day for St Andrew's Day
+      Timecop.travel(Date.parse("2nd December 2013")) do
+        visit "/bank-holidays"
+        assert page.has_no_css?(".app-o-epic-bunting__bunt--tinsel")
+      end
+    end
+
     should "use tinsel bunting for Christmas and New Year bank holidays" do
       Timecop.travel(Date.parse("25th December 2012")) do
         visit "/bank-holidays"


### PR DESCRIPTION
2nd December 2019 is a substitute bank holiday in Scotland for St Andrew's Day. The [current implementation of `Calendar#bunting_styles`](https://github.com/alphagov/calendars/blob/48a6ed35cf2784651441a9024b93a932b4e5f2c1/app/models/calendar.rb#L49-L55) uses tinsel for all bank holidays with `"bunting": true` in December and January, but it should probably only do that for the ones for Christmas and New Year:

![Screenshot 2019-12-02 at 16 55 16](https://user-images.githubusercontent.com/1822424/69979375-14324200-1526-11ea-9f4b-9f4f3344cf90.png)

There were substitute days for St Andrew's Day in 2013 and 2014 as well. I've used one of those in the test because for some reason the test isn't failing today when I use the 2019 date - maybe something to do with Timecop?