### PR TITLE
Change crossorigin from 'anonymous' to 'use-credentials'

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= stylesheet_link_tag 'print', :media => :print %>
     <%= yield :head %>
     <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
-    <%= javascript_include_tag 'application.js', integrity: true, crossorigin: 'anonymous' %>
+    <%= javascript_include_tag 'application.js', integrity: true, crossorigin: 'use-credentials' %>
     <% if @meta_section %>
       <meta name="govuk:section" content="<%= @meta_section %>">
     <% end %>


### PR DESCRIPTION
Small change to the SRI of the JavaScript to use `crossorigin='use-credentials'` rather than `crossorigin='anonymous'`. This change is part of [RFC-114](https://github.com/alphagov/govuk-rfcs/pull/114).