### PR TITLE
Revert "Change crossorigin from 'anonymous' to 'use-credentials'"

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= stylesheet_link_tag 'print', :media => :print %>
     <%= yield :head %>
     <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
-    <%= javascript_include_tag 'application.js', integrity: true, crossorigin: 'use-credentials' %>
+    <%= javascript_include_tag 'application.js', integrity: true, crossorigin: 'anonymous' %>
     <% if @meta_section %>
       <meta name="govuk:section" content="<%= @meta_section %>">
     <% end %>


### PR DESCRIPTION
Reverts alphagov/calendars#757

`Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at ‘https://assets.integration.publishing.service.gov.uk/frontend/frontend-7f9a59db277ec340f1dc70fbf02c886072883f9243a91384b2c6405ecf3be4a9.js’. (Reason: Credential is not supported if the CORS header ‘Access-Control-Allow-Origin’ is ‘*’).`

Need to investigate this issue first.