### PR TITLE
Make the event UIDs for the ical files unique

### DIFF
--- a/lib/ics_renderer.rb
+++ b/lib/ics_renderer.rb
@@ -10,27 +10,25 @@ class ICSRenderer
     output << "METHOD:PUBLISH\r\n"
     output << "PRODID:-//uk.gov/GOVUK calendars//EN\r\n"
     output << "CALSCALE:GREGORIAN\r\n"
-    @events.each_with_index do |event, i|
-      output << render_event(event, i)
-    end
+    @events.each { |event| output << render_event(event) }
     output << "END:VCALENDAR\r\n"
   end
 
-  def render_event(event, sequence)
+  def render_event(event)
     output =  "BEGIN:VEVENT\r\n"
     # The end date is defined as non-inclusive in the RFC (2445 section 4.6.1)
     output << "DTEND;VALUE=DATE:#{(event.date + 1.day).strftime('%Y%m%d')}\r\n"
     output << "DTSTART;VALUE=DATE:#{event.date.strftime('%Y%m%d')}\r\n"
     output << "SUMMARY:#{event.title}\r\n"
-    output << "UID:#{uid(sequence)}\r\n"
+    output << "UID:#{uid(event)}\r\n"
     output << "SEQUENCE:0\r\n"
     output << "DTSTAMP:#{dtstamp}\r\n"
     output << "END:VEVENT\r\n"
   end
 
-  def uid(sequence)
+  def uid(event)
     @path_hash ||= Digest::MD5.hexdigest(@cal_path)
-    "#{@path_hash}-#{sequence}@gov.uk"
+    "#{@path_hash}-#{event.date.iso8601}-#{event.title.delete(' ')}@gov.uk"
   end
 
   def dtstamp


### PR DESCRIPTION
We used to use indices to generate UIDs. This meant that when we deleted
some past bank holidays back in December 2019, the indices pointed to
different events.

Using a combination of event title and event date instead of indices to
create event UIDs means that these will remain unique even when we'll
delete other past bank holidays in the future.

We can use event title and event date to make the UIDs uniques because
there are never going to be two bank holidays with the same name on the
same day.

More info and background can be found here:
- [Commit that deleted old bank holidays](https://github.com/alphagov/calendars/commit/c28e7b570c39a10f60d2ed13b85d477b9a60159e#diff-1569053def8d48383b565a3d2d505529)
- [Issue raised by a member of the public](https://github.com/alphagov/calendars/issues/753)

Resolves #753

Trello card: https://trello.com/c/4MuxUJsy/1715-2-fix-the-event-uids-for-the-ical-files-provided-by-the-calendars-app