### PR TITLE
Remove non-word characters from event UIDs

### DIFF
--- a/lib/ics_renderer.rb
+++ b/lib/ics_renderer.rb
@@ -28,7 +28,7 @@ class ICSRenderer
 
   def uid(event)
     @path_hash ||= Digest::MD5.hexdigest(@cal_path)
-    "#{@path_hash}-#{event.date.iso8601}-#{event.title.delete(' ')}@gov.uk"
+    "#{@path_hash}-#{event.date.iso8601}-#{event.title.gsub(/\W/, '')}@gov.uk"
   end
 
   def dtstamp

--- a/test/unit/ics_renderer_test.rb
+++ b/test/unit/ics_renderer_test.rb
@@ -66,12 +66,12 @@ class ICSRendererTest < ActiveSupport::TestCase
       @path = "/foo/bar.ics"
       @r = ICSRenderer.new([], @path)
       @hash = Digest::MD5.hexdigest(@path)
-      @first_event = Calendar::Event.new("title" => "An important event", "date" => Date.new(1982, 5, 28))
+      @first_event = Calendar::Event.new("title" => "Somebody’s important event", "date" => Date.new(1982, 5, 28))
       @second_event = Calendar::Event.new("title" => "Another important event", "date" => Date.new(1984, 1, 16))
     end
 
     should "use calendar path, event title and event date to create a uid" do
-      assert_equal "#{@hash}-1982-05-28-Animportantevent@gov.uk", @r.uid(@first_event)
+      assert_equal "#{@hash}-1982-05-28-Somebodysimportantevent@gov.uk", @r.uid(@first_event)
     end
 
     should "cache the hash generation" do


### PR DESCRIPTION
Hey,

Thanks again for your work on the bank holiday calendar UID update.

This is a simple piece of defensive programming after observing this UID in the latest production .ics output:
```
BEGIN:VEVENT
DTEND;VALUE=DATE:20150102
DTSTART;VALUE=DATE:20150101
SUMMARY:New Year’s Day
UID:ca6af7456b0088abad9a69f9f620f5ac-2015-01-01-NewYear’sDay@gov.uk
SEQUENCE:0
DTSTAMP:20200210T141037Z
END:VEVENT
```

After my proposed change the UID line will come out as:
```
UID:ca6af7456b0088abad9a69f9f620f5ac-2015-01-01-NewYearsDay@gov.uk
```

Removing non-word characters seemed like the best way to avoid accounting for the text [escaping rules](https://tools.ietf.org/html/rfc5545#section-3.3.11) in the ICS format spec. Without this change, an event name with a `:` or `;` or `,` in could break an otherwise valid ICS file.

Hope this helps!