### PR TITLE
Remove bunting for 2020 Easter Monday

### DIFF
--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -1089,7 +1089,7 @@
                     "title": "bank_holidays.easter_monday",
                     "date": "13/04/2020",
                     "notes": "",
-                    "bunting": true
+                    "bunting": false
                 },
                 {
                     "title": "bank_holidays.early_may_ve",


### PR DESCRIPTION
Given the COVID-19 pandemic and people being asked to stay at home, it would be inappropriate to decorate GOV.UK with bunting at this time.