### PR TITLE
Remove 13/04/2020 bunting for England and Wales

### DIFF
--- a/lib/data/bank-holidays.json
+++ b/lib/data/bank-holidays.json
@@ -273,7 +273,7 @@
                     "title": "bank_holidays.easter_monday",
                     "date": "13/04/2020",
                     "notes": "",
-                    "bunting": true
+                    "bunting": false
                 },
                 {
                     "title": "bank_holidays.early_may_ve",


### PR DESCRIPTION
In 5606d77, bunting was only removed for Northern Ireland.  This also removes the bunting for England & Wales.

Easter Monday is not a bank holiday in Scotland.